### PR TITLE
Time fix

### DIFF
--- a/lib/pavilion/utils.py
+++ b/lib/pavilion/utils.py
@@ -89,7 +89,7 @@ def get_relative_timestamp(base_dt):
         if now.strftime(format_[i]) != base_dt.strftime(format_[i]):
             return now.strftime(" ".join(format_[i:]))
 
-    return now.strftime(str(" ".join(format_[3])))
+    return now.strftime(str(format_[3]))
 
 
 def flat_walk(path, *args, **kwargs):

--- a/lib/pavilion/utils.py
+++ b/lib/pavilion/utils.py
@@ -87,9 +87,9 @@ def get_relative_timestamp(base_dt):
 
     for i in range(0, len(format_)):
         if now.strftime(format_[i]) != base_dt.strftime(format_[i]):
-            return now.strftime(" ".join(format_[i:]))
+            return base_dt.strftime(" ".join(format_[i:]))
 
-    return now.strftime(str(format_[3]))
+    return base_dt.strftime(str(format_[3]))
 
 
 def flat_walk(path, *args, **kwargs):

--- a/lib/pavilion/utils.py
+++ b/lib/pavilion/utils.py
@@ -89,7 +89,7 @@ def get_relative_timestamp(base_dt):
         if now.strftime(format_[i]) != base_dt.strftime(format_[i]):
             return now.strftime(" ".join(format_[i:]))
 
-    return base_dt.strftime(str(" ".join(format_)))
+    return now.strftime(str(" ".join(format_[3])))
 
 
 def flat_walk(path, *args, **kwargs):


### PR DESCRIPTION
Address #73.

- base datetime object's string format of `H:M:S` is returned if there is no differences between datetime object output
- we now return the base datetime object time (we previously returned "now", which was a bug)