### PR TITLE
Cleaned up test completion states

### DIFF
--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -1,4 +1,3 @@
-import sys
 import time
 
 from pavilion import commands
@@ -17,10 +16,10 @@ class WaitCommand(commands.Command):
                           STATES.SCHED_ERROR,
                           STATES.SCHED_CANCELLED,
                           STATES.BUILD_FAILED,
+                          STATES.BUILD_TIMEOUT,
                           STATES.BUILD_ERROR,
                           STATES.ENV_FAILED,
                           STATES.RUN_TIMEOUT,
-                          STATES.RUN_FAILED,
                           STATES.RUN_ERROR,
                           STATES.RESULTS_ERROR,
                           STATES.COMPLETE]

--- a/lib/pavilion/plugins/sched/slurm.py
+++ b/lib/pavilion/plugins/sched/slurm.py
@@ -711,6 +711,7 @@ class Slurm(SchedulerPlugin):
                 STATES.SCHED_CANCELLED,
                 "Job cancelled, has job state '{}'".format(job_state)
             )
+            test.set_run_complete()
             return test.status.current()
 
         self.logger.warning("Encountered unhandled job state '%s' for"

--- a/lib/pavilion/schedulers.py
+++ b/lib/pavilion/schedulers.py
@@ -417,17 +417,22 @@ class SchedulerPlugin(IPlugin.IPlugin):
         """Create the test script and schedule the job.
 
         :param pav_cfg: The pavilion cfg.
-        :param pavilion.test_config.TestRun test_obj: The pavilion test to
+        :param pavilion.test_run.TestRun test_obj: The pavilion test to
         start.
         """
 
         kick_off_path = self._create_kickoff_script(pav_cfg, test_obj)
 
-        test_obj.job_id = self._schedule(test_obj, kick_off_path)
+        try:
+            test_obj.job_id = self._schedule(test_obj, kick_off_path)
 
-        test_obj.status.set(test_obj.status.STATES.SCHEDULED,
-                            "Test {} has job ID {}."
-                            .format(self.name, test_obj.job_id))
+            test_obj.status.set(test_obj.status.STATES.SCHEDULED,
+                                "Test {} has job ID {}."
+                                .format(self.name, test_obj.job_id))
+        except Exception:
+            # If this fails, consider this test done.
+            test_obj.set_run_complete()
+            raise
 
     def _schedule(self, test_obj, kickoff_path):
         """Run the kickoff script at script path with this scheduler.

--- a/lib/pavilion/status_file.py
+++ b/lib/pavilion/status_file.py
@@ -39,8 +39,10 @@ Rules:
 - The constants have a max length of 15 characters.
 - The constants are in all caps.
 - The constants must be a valid python identifier that starts with a letter.
-- Error states should end in '_ERROR'
-- Failure states should end in '_FAILED'
+- Error states should end in '_ERROR'. They should be the result of an OS
+  level problem (like missing directories), or problems with Pavilion itself.
+- Failure states should end in '_FAILED'. They should be the result of trying
+  something, and it just not succeeding.
 
 **Note**: The states are written in the class as ``<state_name> = <help_text>``,
 however, on class init the help text is stored separately, and the state value
@@ -63,13 +65,13 @@ Known States:
     SCHED_CANCELLED = "The job was cancelled."
     BUILDING = "The test is currently being built."
     BUILD_FAILED = "The build has failed."
+    BUILD_TIMEOUT = "The build has timed out."
     BUILD_ERROR = "An unexpected error occurred while setting up the build."
     BUILD_DONE = "The build step has completed."
     ENV_FAILED = "Unable to load the environment requested by the test."
     PREPPING_RUN = "Performing final (on node) steps before the test run."
     RUNNING = "For when we're currently running the test."
     RUN_TIMEOUT = "The test run went long without any output."
-    RUN_FAILED = "The test run has failed."
     RUN_ERROR = "An unexpected error has occurred when setting up the test run."
     RUN_USER = "Jobs can report extra status using pav set_status and " \
                "this status value."
@@ -245,6 +247,12 @@ could be wrong with the file format.
                                   .format(self.path, err))
 
         return [self._parse_status_line(line) for line in lines]
+
+    def has_state(self, state):
+        """Check if the given state is somewhere in the history of this
+        status file."""
+
+        return any([state == h.state for h in self.history()])
 
     def current(self):
         """Return the most recent status object.

--- a/test/tests/mod_wrapper_tests.py
+++ b/test/tests/mod_wrapper_tests.py
@@ -123,7 +123,7 @@ class ModWrapperTests(PavTestCase):
         test = self._quick_test(test_cfg)
         run_result = test.run()
 
-        self.assertEqual(run_result, STATES.RUN_DONE)
+        self.assertEqual(run_result, True)
 
     @unittest.skipIf(not has_module_cmd() and find_module_init() is None,
                      "Could not find a module system.")
@@ -165,7 +165,7 @@ class ModWrapperTests(PavTestCase):
         test = self._quick_test(test_cfg)
         run_result = test.run()
 
-        self.assertEqual(run_result, STATES.RUN_DONE)
+        self.assertEqual(run_result, True)
 
     @unittest.skipIf(not has_module_cmd() and find_module_init() is None,
                      "Could not find a module system.")
@@ -201,7 +201,7 @@ class ModWrapperTests(PavTestCase):
         test = self._quick_test(test_cfg)
         run_result = test.run()
 
-        self.assertEqual(run_result, STATES.RUN_DONE)
+        self.assertEqual(run_result, True)
 
     @unittest.skipIf(not has_module_cmd() and find_module_init() is None,
                      "Could not find a module system.")
@@ -217,7 +217,7 @@ class ModWrapperTests(PavTestCase):
         # Make sure we fail for a non-existent module.
         test = self._quick_test(test_cfg)
         test.run()
-        self.assertEqual(test.status.current().state, STATES.ENV_FAILED)
+        self.assertTrue(test.status.has_state(STATES.ENV_FAILED))
 
         test_cfg['run']['modules'] = [
             'test_mod1',
@@ -226,8 +226,8 @@ class ModWrapperTests(PavTestCase):
 
         test = self._quick_test(test_cfg)
         test.run()
-        self.assertEqual(test.status.current().state, STATES.ENV_FAILED,
-                         msg=(test.path/'run.log').open().read())
+        self.assertTrue(test.status.has_state(STATES.ENV_FAILED),
+                        msg=(test.path/'run.log').open().read())
 
     @unittest.skipIf(not has_module_cmd() and find_module_init() is None,
                      "Could not find a module system.")

--- a/test/tests/test_run_tests.py
+++ b/test/tests/test_run_tests.py
@@ -302,7 +302,7 @@ class TestRunTests(PavTestCase):
 
         self.assertEqual(
             test.run(),
-            STATES.RUN_FAILED,
+            False,
             msg="Test should have failed because a module couldn't be "
                 "loaded. {}".format(test.path))
         # TODO: Make sure this is the exact reason for the failure
@@ -321,11 +321,10 @@ class TestRunTests(PavTestCase):
         test = TestRun(self.pav_cfg, config3, VariableSetManager())
         self.assert_(test.build())
         test.finalize(VariableSetManager())
-        self.assertEqual(
-            test.run(),
-            STATES.RUN_TIMEOUT,
-            msg="Test should have failed due to timeout. {}"
-                .format(test.path))
+        with self.assertRaises(TimeoutError,
+                               msg="Test should have failed due "
+                                   "to timeout. {}"):
+            test.run()
 
     def test_suites(self):
         """Test suite creation and regeneration."""


### PR DESCRIPTION
 - Removed RUN_FAILED as a state.
   - Runs now return True (if the run.sh returned zero), false otherwise.
   - They may also raise a TimeoutError.
 - Made the create of the 'RUN_COMPLETE' file happen anytime a test run
   encounters an error that will prevent it from continuing.