### PR TITLE
pav wait --no-timeout flag

### DIFF
--- a/lib/pavilion/plugins/commands/status.py
+++ b/lib/pavilion/plugins/commands/status.py
@@ -69,6 +69,50 @@ def get_all_tests(pav_cfg, args, errfile):
     return test_statuses
 
 
+def get_tests(pav_cfg, args, errfile):
+    """
+    Gets the tests depending on arguments.
+
+:param pav_cfg: The pavilion config
+:param argparse namespace args: The tests via command line args.
+:param errfile: stream to output errors as needed
+:return: List of test objects
+    """
+
+    if not args.tests:
+        # Get the last series ran by this user
+        series_id = series.TestSeries.load_user_series_id(pav_cfg)
+        if series_id is not None:
+            args.tests.append(series_id)
+        else:
+            raise commands.CommandError(
+                "No tests specified and no last sries was found."
+            )
+
+    test_list = []
+
+    for test_id in args.tests:
+        # Series
+        if test_id.startswith('s'):
+            try:
+                test_list.extend(series.TestSeries.from_id(pav_cfg,
+                                                           test_id).tests)
+            except series.TestSeriesError as err:
+                output.fprint(
+                    "Suite {} could not be found.\n{}"
+                    .format(test_id, error),
+                    file=errfile,
+                    color=output.RED
+                )
+                continue
+        # Test
+        else:
+            test_list.append(test_id)
+
+    test_list = list(map(int, test_list))
+    return test_list
+
+
 def get_statuses(pav_cfg, args, errfile):
     """Get the statuses of the listed tests or series.
 
@@ -80,38 +124,7 @@ def get_statuses(pav_cfg, args, errfile):
           note.
 """
 
-    # if (not args.tests) and (not args.all):
-    if not args.tests:
-        # Get the last series ran by this user.
-        series_id = series.TestSeries.load_user_series_id(pav_cfg)
-        if series_id is not None:
-            args.tests.append(series_id)
-        else:
-            raise commands.CommandError(
-                "No tests specified and no last series was found.")
-
-    test_list = []
-
-    for test_id in args.tests:
-        # Series
-        if test_id.startswith('s'):
-            try:
-                test_list.extend(
-                    series.TestSeries.from_id(pav_cfg, test_id).tests)
-            except series.TestSeriesError as err:
-                output.fprint(
-                    "Suite {} could not be found.\n{}"
-                    .format(test_id, err),
-                    file=errfile,
-                    color=output.RED
-                )
-                continue
-        # Test
-        else:
-            test_list.append(test_id)
-
-    test_list = list(map(int, test_list))
-
+    test_list = get_tests(pav_cfg, args, errfile)
     test_statuses = []
     test_obj_list = []
     for test_id in test_list:

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -74,12 +74,12 @@ class WaitCommand(commands.Command):
             if not args.silent:
                 if time.time() > (start_time + 5*periodic_status_count):
                     for test in tmp_statuses:
-                         stat = [str(time.ctime(time.time())), ':',
-                                 str(test['test_id']),
-                                 test['name'],
-                                 test['state'],
-                                 test['note']]
-                         fprint(' '.join(stat))
+                        stat = [str(time.ctime(time.time())), ':',
+                                  str(test['test_id']),
+                                  test['name'],
+                                  test['state'],
+                                  test['note']]
+                        fprint(' '.join(stat))
                     periodic_status_count += 1
 
         ret_val = status.print_status(tmp_statuses, self.outfile, args.json)

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -75,10 +75,10 @@ class WaitCommand(commands.Command):
                 if time.time() > (start_time + 5*periodic_status_count):
                     for test in tmp_statuses:
                          stat = [str(time.ctime(time.time())), ':',
-                               str(test['test_id']),
-                               test['name'],
-                               test['state'],
-                               test['note']]
+                                 str(test['test_id']),
+                                 test['name'],
+                                 test['state'],
+                                 test['note']]
                          fprint(' '.join(stat))
                     periodic_status_count += 1
 

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -74,7 +74,8 @@ class WaitCommand(commands.Command):
             if not args.silent:
                 if time.time() > (start_time + 5*periodic_status_count):
                     for test in tmp_statuses:
-                        stat = [str(time.ctime(time.time())), ':',
+                        stat = [str(time.ctime(time.time())), ':', 
+                                'test #',
                                 str(test['test_id']),
                                 test['name'],
                                 test['state'],

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -75,10 +75,10 @@ class WaitCommand(commands.Command):
                 if time.time() > (start_time + 5*periodic_status_count):
                     for test in tmp_statuses:
                         stat = [str(time.ctime(time.time())), ':',
-                                  str(test['test_id']),
-                                  test['name'],
-                                  test['state'],
-                                  test['note']]
+                                str(test['test_id']),
+                                test['name'],
+                                test['state'],
+                                test['note']]
                         fprint(' '.join(stat))
                     periodic_status_count += 1
 

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -31,21 +31,14 @@ class WaitCommand(commands.Command):
             help='Give output as json, rather than as standard human readable.'
         )
         parser.add_argument(
+            '-t', '--timeout', action='store', default=60,
+            help='Maximum time to wait for results in seconds. Default=60.'
+        )
+        parser.add_argument(
             'tests', nargs='*', action='store',
             help='The name(s) of the tests to check.  These may be any mix of '
                  'test IDs and series IDs.  If no value is provided, the most '
                  'recent series submitted by this user is checked.'
-        )
-
-        timeout_group = parser.add_mutually_exclusive_group()
-        timeout_group.add_argument(
-            '-t', '--timeout', action='store', default='60',
-            help='Maximum time to wait for results in seconds. Default=60.'
-        )
-        timeout_group.add_argument(
-            '--no-timeout', action='store_true',
-            help="Will not return nor display status until test/s is/are "
-                 "completed."
         )
 
     def run(self, pav_cfg, args):

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -31,7 +31,7 @@ class WaitCommand(commands.Command):
             help='Give output as json, rather than as standard human readable.'
         )
         parser.add_argument(
-            '-t', '--timeout', action='store', default=60,
+            '-t', '--timeout', action='store', 
             help='Maximum time to wait for results in seconds. Default=60.'
         )
         parser.add_argument(

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -73,14 +73,12 @@ class WaitCommand(commands.Command):
             # print status every 5 seconds
             if not args.silent:
                 if time.time() > (start_time + 5*periodic_status_count):
-                    from pavilion.output import fprint
                     for test in tmp_statuses:
                        stat = [str(time.ctime(time.time())), ':',
                                str(test['test_id']),
                                test['name'],
                                test['state'],
-                               test['note']
-                               ]
+                               test['note']]
                        fprint(' '.join(stat))
                     periodic_status_count += 1
 

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -74,7 +74,7 @@ class WaitCommand(commands.Command):
             if not args.silent:
                 if time.time() > (start_time + 5*periodic_status_count):
                     for test in tmp_statuses:
-                        stat = [str(time.ctime(time.time())), ':', 
+                        stat = [str(time.ctime(time.time())), ':',
                                 'test #',
                                 str(test['test_id']),
                                 test['name'],

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -54,7 +54,6 @@ class WaitCommand(commands.Command):
         start_time = time.time()
 
         tests = status.get_tests(pav_cfg, args, self.errfile)
-        tot_tests = len(tests)
 
         # determine timeout time, if there is one
         end_time = None

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -74,12 +74,12 @@ class WaitCommand(commands.Command):
             if not args.silent:
                 if time.time() > (start_time + 5*periodic_status_count):
                     for test in tmp_statuses:
-                       stat = [str(time.ctime(time.time())), ':',
+                        stat = [str(time.ctime(time.time())), ':',
                                str(test['test_id']),
                                test['name'],
                                test['state'],
                                test['note']]
-                       fprint(' '.join(stat))
+                        fprint(' '.join(stat))
                     periodic_status_count += 1
 
         ret_val = status.print_status(tmp_statuses, self.outfile, args.json)

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -74,12 +74,12 @@ class WaitCommand(commands.Command):
             if not args.silent:
                 if time.time() > (start_time + 5*periodic_status_count):
                     for test in tmp_statuses:
-                        stat = [str(time.ctime(time.time())), ':',
+                         stat = [str(time.ctime(time.time())), ':',
                                str(test['test_id']),
                                test['name'],
                                test['state'],
                                test['note']]
-                        fprint(' '.join(stat))
+                         fprint(' '.join(stat))
                     periodic_status_count += 1
 
         ret_val = status.print_status(tmp_statuses, self.outfile, args.json)

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -1,4 +1,5 @@
 import time
+import sys
 
 from pavilion import commands
 from pavilion.plugins.commands import status
@@ -40,6 +41,9 @@ class WaitCommand(commands.Command):
                  'test IDs and series IDs.  If no value is provided, the most '
                  'recent series submitted by this user is checked.'
         )
+        parser.add_argument(
+            '-s', '--silent', action='store_true'
+        )
 
     def run(self, pav_cfg, args):
 
@@ -52,8 +56,8 @@ class WaitCommand(commands.Command):
         if args.timeout is not None:
             end_time = time.time() + float(args.timeout)
 
-        while (final_statuses < len(tmp_statuses) and
-              (end_time is None or time.time() < end_time)):
+        while (final_statuses < len(tmp_statuses) and (end_time is None or
+                                                       time.time() < end_time)):
             # Check which tests have completed or failed and move them to the
             # final list.
             final_statuses = 0
@@ -64,5 +68,6 @@ class WaitCommand(commands.Command):
             tmp_statuses = status.get_statuses(pav_cfg, args, self.errfile)
 
         ret_val = status.print_status(tmp_statuses, self.outfile, args.json)
+
 
         return ret_val

--- a/lib/pavilion/plugins/commands/wait.py
+++ b/lib/pavilion/plugins/commands/wait.py
@@ -4,6 +4,7 @@ import sys
 from pavilion import commands
 from pavilion.plugins.commands import status
 from pavilion.status_file import STATES
+from pavilion.output import fprint
 
 
 class WaitCommand(commands.Command):
@@ -80,10 +81,9 @@ class WaitCommand(commands.Command):
                                test['state'],
                                test['note']
                                ]
-                       print(' '.join(stat))
+                       fprint(' '.join(stat))
                     periodic_status_count += 1
 
         ret_val = status.print_status(tmp_statuses, self.outfile, args.json)
-
 
         return ret_val

--- a/test/tests/wait_cmd_tests.py
+++ b/test/tests/wait_cmd_tests.py
@@ -26,7 +26,6 @@ class WaitCmdTests(PavTestCase):
         self.assertEqual(args.tests[0], 'test1')
         self.assertEqual(args.tests[1], 'test2')
         self.assertEqual(args.json, False)
-        self.assertEqual(args.timeout, '60')
 
         parser = argparse.ArgumentParser()
         wait_cmd._setup_arguments(parser)


### PR DESCRIPTION
Added an option to `pav wait` to not have a timeout #132 

- [x] default should be no timeout (remove `--no-timeout` flag)
- [x] `--silent` (prints every 5 seconds)
- [x] change conditional
- [x] make status output prettier

Note:
- If using the `timeout` flag (`pav wait --timeout <value>`) a value is now required.
- Updates look something like this: 
`Wed Mar  4 16:01:24 2020 : test # 41 timeout.basic RUNNING Currently running.`