### PR TITLE
Fixed fprint fix (and consequences)

### DIFF
--- a/lib/pavilion/output.py
+++ b/lib/pavilion/output.py
@@ -102,34 +102,40 @@ print dbg statements and easily excise it later.
 
 
 def fprint(*args, color=None, bullet='', width=100,
-           sep=' ', file=sys.stdout):
-    """Print with automatic wrapping, bullets, and other features.
+           sep=' ', file=sys.stdout, end='\n', flush=False):
+    """Print with automatic wrapping, bullets, and other features. Also accepts
+    all print() kwargs.
 
     :param args: Standard print function args
     :param int color: ANSI color code to print with.
-    :param str bullet: Print the first line with this 'bullet' string,
-        and the following lines indented to match..
+    :param str bullet: Print the first line with this 'bullet' string, and the
+        following lines indented to match.
     :param str sep: The standard print sep argument.
     :param file: Stream to print.
     :param int width: Wrap the text to this width.
-    """
+    :param str end: String appended after the last value (default \\n)
+    :param bool flush: Whether to forcibly flush the stream.
+"""
 
     args = [str(a) for a in args]
     if color is not None:
         print('\x1b[{}m'.format(color), end='', file=file)
 
     out_str = sep.join(args)
-    for paragraph in str.splitlines(out_str):
-        lines = textwrap.wrap(paragraph, width=width)
-        lines = '\n'.join(lines)
+    if width is not None:
+        for paragraph in str.splitlines(out_str):
+            lines = textwrap.wrap(paragraph, width=width)
+            lines = '\n'.join(lines)
 
-        if bullet:
-            lines = textwrap.indent(lines, bullet, lines.startswith)
+            if bullet:
+                lines = textwrap.indent(lines, bullet, lines.startswith)
 
-        print(lines, file=file)
+            print(lines, file=file)
+    else:
+        print(out_str, file=file)
 
     if color is not None:
-        print('\x1b[0m', end='', file=file)
+        print('\x1b[0m', end=end, file=file, flush=flush)
 
 
 def json_dumps(obj, skipkeys=False, ensure_ascii=True,

--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -50,10 +50,6 @@ class RunCommand(commands.Command):
                  'names. Lines that start with a \'#\' are ignored as '
                  'comments.')
         parser.add_argument(
-            '-j', '--json', action='store_true', default=False,
-            help='Give output as json, rather than as standard human readable.'
-        )
-        parser.add_argument(
             '-w', '--wait', action='store', type=int, default=None,
             help='Wait this many seconds to make sure at least one test '
                  'started before returning. If a test hasn\'t started by '
@@ -217,7 +213,11 @@ class RunCommand(commands.Command):
         if args.status:
             tests = list(series.tests.keys())
             tests, _ = test_obj_from_id(pav_cfg, tests)
-            return print_from_test_obj(pav_cfg, tests, self.outfile, args.json)
+            return print_from_test_obj(
+                pav_cfg=pav_cfg,
+                test_obj=tests,
+                outfile=self.outfile,
+                json=False)
 
         return 0
 

--- a/lib/pavilion/plugins/sched/slurm_mpi.py
+++ b/lib/pavilion/plugins/sched/slurm_mpi.py
@@ -23,4 +23,3 @@ class SlurmMPI(slurm.Slurm):
             'Schedules tests via Slurm but runs them using mpirun',
             priority=10
         )
-

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -97,25 +97,3 @@ class RunCmdTests(PavTestCase):
         run_cmd.outfile = io.StringIO()
 
         self.assertEqual(run_cmd.run(self.pav_cfg, args), 0)
-
-    def test_run_status_json(self):
-        '''Tests run command with status and json flags'''
-
-        arg_parser = arguments.get_parser()
-
-        args = arg_parser.parse_args([
-            'run',
-            '-s', '-j',
-            'hello_world'
-        ])
-
-        run_cmd = commands.get_command(args.command_name)
-        run_cmd.outfile = io.StringIO()
-
-        self.assertEqual(run_cmd.run(self.pav_cfg, args), 0)
-
-        status = run_cmd.outfile.getvalue().split('\n')[-1].strip().encode('UTF-8')
-        status = status[4:].decode('UTF-8')
-        status = json.loads(status)
-
-        self.assertNotEqual(len(status), 0)


### PR DESCRIPTION
 - fprint now takes all 'print' args like it was supposed to.
 - Fixed style error in slurm_mpi.py
 - Dropped json output from run command and test
   - It doesn't make sense to have such formal output on a command with
     messy output. Use 'pav status -j' instead.