### PR TITLE
fix typos in output help messages

### DIFF
--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -53,7 +53,7 @@ class RunCommand(commands.Command):
             '-w', '--wait', action='store', type=int, default=None,
             help='Wait this many seconds to make sure at least one test '
                  'started before returning. If a test hasn\'t started by '
-                 'then, cancel all tests and return a failure. Defaults to'
+                 'then, cancel all tests and return a failure. Defaults to '
                  'not checking tests before returning.'
         )
         parser.add_argument(

--- a/lib/pavilion/result_parsers.py
+++ b/lib/pavilion/result_parsers.py
@@ -591,8 +591,8 @@ configured for that test.
                 'result_parser': None,
                 'file': None,
                 'key': 'result',
-                'msg': "A result parser set the 'result' key to {}, but it must"
-                       " be strictly set to True/False (PASS/FAIL)."
+                'msg': "A result parser set the 'result' key to {}, but it "
+                       "must be strictly set to True/False (PASS/FAIL)."
                        .format(results['result'])
             })
 

--- a/lib/pavilion/result_parsers.py
+++ b/lib/pavilion/result_parsers.py
@@ -591,7 +591,7 @@ configured for that test.
                 'result_parser': None,
                 'file': None,
                 'key': 'result',
-                'msg': "A result parser set the 'result' key to {}, but it must"
+                'msg': "A result parser set the 'result' key to {}, but it must "
                        "be strictly set to True/False (PASS/FAIL)."
                        .format(results['result'])
             })

--- a/lib/pavilion/result_parsers.py
+++ b/lib/pavilion/result_parsers.py
@@ -591,8 +591,8 @@ configured for that test.
                 'result_parser': None,
                 'file': None,
                 'key': 'result',
-                'msg': "A result parser set the 'result' key to {}, but it must "
-                       "be strictly set to True/False (PASS/FAIL)."
+                'msg': "A result parser set the 'result' key to {}, but it must"
+                       " be strictly set to True/False (PASS/FAIL)."
                        .format(results['result'])
             })
 


### PR DESCRIPTION
Two typos I found while perusing through pav. 