### PR TITLE
Check for unavailable schedulers

### DIFF
--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -197,6 +197,16 @@ class RunCommand(commands.Command):
 
         all_tests = sum(tests_by_sched.values(), [])
 
+        for sched_name in tests_by_sched.keys():
+            sched = schedulers.get_plugin(sched_name)
+
+            if not sched.available():
+                fprint("{} tests started with the {} scheduler, but "
+                       "that scheduler isn't available on this system."
+                       .format(len(tests_by_sched[sched_name]), sched_name),
+                       file=self.errfile, color=output.RED)
+                return errno.EINVAL
+
         for sched_name, tests in tests_by_sched.items():
             sched = schedulers.get_plugin(sched_name)
 

--- a/lib/pavilion/plugins/sched/raw.py
+++ b/lib/pavilion/plugins/sched/raw.py
@@ -185,6 +185,11 @@ class Raw(SchedulerPlugin):
                 state=STATES.SCHED_ERROR,
                 note=msg)
 
+    def available(self):
+        """The raw scheduler is always available."""
+
+        return True
+
     def _schedule(self, test_obj, kickoff_path):
         """Run the kickoff script in a separate process. The job id a
         combination of the hostname and pid.

--- a/lib/pavilion/schedulers.py
+++ b/lib/pavilion/schedulers.py
@@ -405,6 +405,14 @@ class SchedulerPlugin(IPlugin.IPlugin):
 
         return datetime.datetime.now()
 
+    def available(self):
+        """Returns true if this scheduler is available on this host.
+
+        :rtype: bool
+        """
+
+        raise NotImplementedError
+
     def job_status(self, pav_cfg, test):
         """Get the job state from the scheduler, and map it to one of the
         on of the following states: SCHEDULED, SCHED_ERROR, SCHED_CANCELLED.

--- a/test/data/pav_config_dir/plugins/schedulers/dummy.py
+++ b/test/data/pav_config_dir/plugins/schedulers/dummy.py
@@ -1,8 +1,6 @@
+import yaml_config as yc
 from pavilion import schedulers
 from pavilion.status_file import STATES
-from pavilion.test_config import VariableSetManager
-from pavilion.system_variables import SysVarDict
-import yaml_config as yc
 
 
 class DummyVars(schedulers.SchedulerVariables):
@@ -26,6 +24,9 @@ class Dummy(schedulers.SchedulerPlugin):
         """The dummy scheduler does nothing, because it's dumb."""
 
         return ""
+
+    def available(self):
+        return True
 
     def job_status(self, pav_cfg, test):
         """Dummy jobs are always ok, because they're dumb."""

--- a/test/data/pav_config_dir/plugins/schedulers/not_available.py
+++ b/test/data/pav_config_dir/plugins/schedulers/not_available.py
@@ -1,0 +1,19 @@
+import yaml_config as yc
+from pavilion import schedulers
+
+
+class NotAvailable(schedulers.SchedulerPlugin):
+
+    VAR_CLASS = schedulers.SchedulerVariables
+
+    def __init__(self):
+        super().__init__('not_available', description="Not Available")
+
+    def get_conf(self):
+        return yc.KeyedElem('not_available', elements=[])
+
+    def _schedule(self, test_obj, kickoff_path):
+        return ""
+
+    def available(self):
+        return False

--- a/test/data/pav_config_dir/plugins/schedulers/not_available.yapsy-plugin
+++ b/test/data/pav_config_dir/plugins/schedulers/not_available.yapsy-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = NotAvailable
+Module = not_available
+
+[Documentation]
+Description = A Dummy scheduler that isn't available
+Author = Some Author
+Version = 1.0
+Website =

--- a/test/data/pav_config_dir/tests/not_available.yaml
+++ b/test/data/pav_config_dir/tests/not_available.yaml
@@ -1,0 +1,2 @@
+nope:
+  scheduler: not_available

--- a/test/tests/doc_tests.py
+++ b/test/tests/doc_tests.py
@@ -25,7 +25,7 @@ class DocTests(PavTestCase):
         self.external_links = None
 
     def setUp(self):
-        """Bujld the docs only once."""
+        """Build the docs only once."""
 
         if not self.docs_built:
             out, ret = self.build_docs()

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -182,3 +182,14 @@ class RunCmdTests(PavTestCase):
         run_cmd = commands.get_command(args.command_name)
         self.assertEqual(run_cmd.run(self.pav_cfg, args), 0)
 
+    def test_no_sched(self):
+        """Check that we get a reasonable error for a non-available
+        scheduler."""
+
+        arg_parser = arguments.get_parser()
+        args = arg_parser.parse_args([
+            'run', 'not_available'
+        ])
+
+        run_cmd = commands.get_command(args.command_name)
+        self.assertNotEqual(run_cmd.run(self.pav_cfg, args), 0)


### PR DESCRIPTION
Scheduler plugins must now implement an 'available()' method.
 - Test runs will fail when trying to run a test under an
   unavailable schedulers.
 - Added a unit test for this.