### PR TITLE
if skip, set run complete

### DIFF
--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -939,6 +939,7 @@ directory that doesn't already exist.
             return False
         else:
             self.status.set(STATES.COMPLETE, matches)
+            self.set_run_complete()
             return True
 
     def _evaluate_skip_conditions(self):

--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -938,7 +938,7 @@ directory that doesn't already exist.
         if len(skip_reason_list) == 0:
             return False
         else:
-            self.status.set(STATES.COMPLETE, matches)
+            self.status.set(STATES.SKIPPED, matches)
             self.set_run_complete()
             return True
 


### PR DESCRIPTION
With Francine using some conditional test functionality she noticed that a `RUN_COMPLETE` file wasn't being placed in tests that were completed based on skips.