### PR TITLE
Fixed issue with 'repair_symlinks'

### DIFF
--- a/lib/pavilion/builder.py
+++ b/lib/pavilion/builder.py
@@ -436,12 +436,18 @@ class TestBuilder:
                         # into the test run, and set the run as complete.
                         return False
 
-                    # Make all symlinks relative so they can be moved
-                    # cleanly.
-                    utils.repair_symlinks(build_dir)
+                    try:
+                        # Make all symlinks relative if they're internal
+                        utils.repair_symlinks(build_dir)
 
-                    # Rename the build to it's final location.
-                    build_dir.rename(self.path)
+                        # Rename the build to it's final location.
+                        build_dir.rename(self.path)
+                    except (OSError, ValueError) as err:
+                        self.tracker.error(
+                            "Unexpected error: {}".format(err.args[0])
+                        )
+                        cancel_event.set()
+                        return False
 
                     # Make a file with the test id of the building test.
                     try:

--- a/lib/pavilion/utils.py
+++ b/lib/pavilion/utils.py
@@ -179,6 +179,8 @@ class ZipFileFixed(zipfile.ZipFile):
 def repair_symlinks(base: Path) -> None:
     """Makes all symlinks under the path 'base' relative."""
 
+    base = base.resolve()
+
     for file in flat_walk(base):
 
         if file.is_symlink():
@@ -186,7 +188,8 @@ def repair_symlinks(base: Path) -> None:
             # for Path.readlink has already been merged in the Python develop
             # branch)
             target = Path(os.readlink(file.as_posix()))
-            if target.is_absolute():
+            target = Path(resolve_path(target))
+            if target.is_absolute() and dir_contains(target, base):
                 rel_target = target.relative_to(base)
                 file.unlink()
                 file.symlink_to(rel_target)


### PR DESCRIPTION
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/var/lib/perceus/vnfs/asc-fe/rootfs/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/var/lib/perceus/vnfs/asc-fe/rootfs/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/yellow/usr/projects/hpctest/jogas/git/pavilion2/lib/pavilion/test_run.py", line 514, in build
    if self.builder.build(cancel_event=cancel_event):
  File "/yellow/usr/projects/hpctest/jogas/git/pavilion2/lib/pavilion/builder.py", line 441, in build
    utils.repair_symlinks(build_dir)
  File "/yellow/usr/projects/hpctest/jogas/git/pavilion2/lib/pavilion/utils.py", line 190, in repair_symlinks
    rel_target = target.relative_to(base)
  File "/var/lib/perceus/vnfs/asc-fe/rootfs/usr/lib64/python3.6/pathlib.py", line 874, in relative_to
    .format(str(self), str(formatted)))
ValueError: '/yellow/usr/projects/hpctest/jogas/git/pavilion2/working_dir/builds/2f4e5c9265c2cdef.tmp/Make.CTS1' does not start with '/usr/projects/hpctest/jogas/git/pavilion2/working_dir/builds/2f4e5c9265c2cdef.tmp'

BUILD_DONE: 1
1 test started as test series s19.