### PR TITLE
Status summary

### DIFF
--- a/lib/pavilion/plugins/commands/status.py
+++ b/lib/pavilion/plugins/commands/status.py
@@ -224,8 +224,7 @@ def display_history(pav_cfg, args, outfile):
     return ret_val
 
 
-def print_summary(statuses, outfile, json=False):
-
+def print_summary(statuses, outfile):
     """Print_summary takes in a list of test statuses.
         It summarizes basic state output and displays
         the data to the user through draw_table.
@@ -233,7 +232,6 @@ def print_summary(statuses, outfile, json=False):
         :param outfile:
         :rtype: int
         """
-
     total_tests = len(statuses)
     one_success = False
     total_pass = 0
@@ -425,7 +423,7 @@ class StatusCommand(commands.Command):
             return 1
         
         if args.summary:
-            return print_summary(test_statuses, self.outfile, args.json)
+            return print_summary(test_statuses, self.outfile)
         elif args.history:
             return display_history(pav_cfg, args, self.outfile)
         else:

--- a/lib/pavilion/plugins/commands/status.py
+++ b/lib/pavilion/plugins/commands/status.py
@@ -225,6 +225,7 @@ def display_history(pav_cfg, args, outfile):
 
 
 def print_summary(statuses, outfile, json=False):
+
     """Print_summary takes in a list of test statuses.
         It summarizes basic state output and displays
         the data to the user through draw_table.
@@ -257,8 +258,8 @@ def print_summary(statuses, outfile, json=False):
             total_skipped += 1
 
         elif 'RUNNING' in test['state'] or \
-                'SCHEDULED' in test['state'] or \
-                'PREPPING_RUN' in test['state']:
+             'SCHEDULED' in test['state'] or \
+             'PREPPING_RUN' in test['state']:
             state_running += 1
 
         else:

--- a/lib/pavilion/plugins/commands/status.py
+++ b/lib/pavilion/plugins/commands/status.py
@@ -14,8 +14,6 @@ from pavilion import series
 from pavilion import test_run
 from pavilion.status_file import STATES
 from pavilion.test_run import TestRun, TestRunError, TestRunNotFoundError
-from pavilion.output import dbg_print
-from pavilion.output import dbg_print
 
 
 def get_last_ctime(path):

--- a/lib/pavilion/plugins/commands/status.py
+++ b/lib/pavilion/plugins/commands/status.py
@@ -135,7 +135,6 @@ def get_tests(pav_cfg, args, errfile):
         # Test
         else:
             test_list.append(test_id)
-    
     test_list = list(map(int, test_list))
     return test_list
 
@@ -318,7 +317,6 @@ def print_summary(statuses, outfile):
                       border=True,
                       title='Test Summary'
                       )
-
     return ret_val
 
 
@@ -342,7 +340,6 @@ def print_status(statuses, outfile, json=False):
     if json:
         json_data = {'statuses': statuses}
         output.json_dump(json_data, outfile)
-
     else:
         fields = ['test_id', 'name', 'state', 'time', 'note']
         output.draw_table(

--- a/lib/pavilion/plugins/commands/status.py
+++ b/lib/pavilion/plugins/commands/status.py
@@ -226,12 +226,13 @@ def display_history(pav_cfg, args, outfile):
 
 def print_summary(statuses, outfile):
     """Print_summary takes in a list of test statuses.
-        It summarizes basic state output and displays
-        the data to the user through draw_table.
-        :param statuses: state list of current jobs
-        :param outfile:
-        :rtype: int
-        """
+    It summarizes basic state output and displays
+    the data to the user through draw_table.
+    :param statuses: state list of current jobs
+    :param outfile:
+    :rtype: int
+    """
+
     total_tests = len(statuses)
     one_success = False
     total_pass = 0
@@ -269,8 +270,8 @@ def print_summary(statuses, outfile):
         total_pass = 0
         total_fail = 0
     else:
-        total_pass = total_pass / state_completed
-        total_fail = total_fail / state_completed
+        total_pass = total_pass/state_completed
+        total_fail = total_fail/state_completed
 
     fields = ['State', 'Amount', 'Percent', 'PASSED', 'FAILED']
     try:
@@ -278,7 +279,8 @@ def print_summary(statuses, outfile):
             {'State': output.ANSIString('COMPLETED', output.COLORS.get(
                 'GREEN')),
              'Amount': state_completed,
-             'Percent': '{0:.0%}'.format(state_completed / total_tests),
+             'Percent': '{0:.0%}'.format(state_completed/total_tests),
+
              'PASSED': '{0:.0%}'.format(total_pass),
              'FAILED': '{0:.0%}'.format(total_fail)},
 
@@ -294,8 +296,8 @@ def print_summary(statuses, outfile):
 
             {'State': output.ANSIString('SKIPPED', output.COLORS.get('YELLOW')),
              'Amount': total_skipped,
-             'Percent': '{0:.0%}'.format(total_skipped / total_tests)}
-        ]
+             'Percent': '{0:.0%}'.format(total_skipped/total_tests)}]
+
     except ArithmeticError:
         output.fprint("No tests found in the working dir.", color=output.RED)
         return errno.EINVAL
@@ -316,7 +318,9 @@ def print_summary(statuses, outfile):
                       fields=fields,
                       rows=rows,
                       border=True,
-                      title='Test Summary')
+                      title='Test Summary'
+                      )
+
     return ret_val
 
 

--- a/test/tests/status_cmd_tests.py
+++ b/test/tests/status_cmd_tests.py
@@ -122,12 +122,6 @@ class StatusCmdTests(PavTestCase):
         args = parser.parse_args(arg_list)
         self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
 
-        parser = argparse.ArgumentParser()
-        status_cmd._setup_arguments(parser)
-        arg_list = ['-s'] + test_str.split()
-        args = parser.parse_args(arg_list)
-        self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
-
 
     def test_set_status_command(self):
         """Test set status command by generating a suite of tests."""
@@ -234,6 +228,7 @@ class StatusCmdTests(PavTestCase):
         # TODO: Test that the above have actually been set.
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     def test_history_status(self):
         """Checks pav status --history $id command when
         passed a valid and invalid test id.
@@ -250,54 +245,40 @@ class StatusCmdTests(PavTestCase):
         configs = [test_cfg1, test_cfg2, test_cfg3]
 =======
     def goober_test_status_summary(self):
+=======
+    def test_status_summary(self):
+>>>>>>> add summary flag for status output
         # Testing that status works with summary flag
-        config1 = file_format.TestConfigLoader().validate({
-            'scheduler': 'raw',
-            'run': {
-                'env': {
-                    'foo': 'bar',
-                },
-                'cmds': ['echo "I $foo, punks"'],
-            },
-        })
+        status_cmd = commands.get_command('status')
+        status_cmd.outfile = io.StringIO()
+        parser = argparse.ArgumentParser()
+        status_cmd._setup_arguments(parser)
+        arg_list = ['-s', '-a']
+        args = parser.parse_args(arg_list)
 
-        config1['name'] = 'run_test0'
+        # Test that an empty working_dir fails correctly
+        self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
 
-        config2 = file_format.TestConfigLoader().validate({
-            'scheduler': 'raw',
-            'run': {
-                'env': {
-                    'too': 'tar',
-                },
-                'cmds': ['echo "I $too, punks"'],
-            },
-        })
-
-        config2['name'] = 'run_test1'
-
-        config3 = file_format.TestConfigLoader().validate({
-            'scheduler': 'raw',
-            'run': {
-                'env': {
-                    'too': 'tar',
-                },
-                'cmds': ['sleep 10'],
-            },
-        })
-
-        config3['name'] = 'run_test2'
-
-        configs = [config1, config2, config3]
-
+<<<<<<< HEAD
         var_man = VariableSetManager()
 >>>>>>> work on unit tests
+=======
+        base_cfg = self._quick_test_cfg()
+        test_cfg1 = base_cfg.copy()
+        test_cfg1['name'] = 'test1'
+        test_cfg2 = base_cfg.copy()
+        test_cfg2['name'] = 'test2'
+        test_cfg3 = base_cfg.copy()
+        test_cfg3['name'] = 'test3'
+>>>>>>> add summary flag for status output
 
+        configs = [test_cfg1, test_cfg2, test_cfg3]
         tests = [TestRun(self.pav_cfg, test)
                  for test in configs]
-
         for test in tests:
             test.RUN_SILENT_TIMEOUT = 1
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         suite = TestSeries(self.pav_cfg, tests)
         test_str = " ".join([str(test) for test in suite.tests])
@@ -338,3 +319,7 @@ class StatusCmdTests(PavTestCase):
         print(status_cmd.run(self.pav_cfg, args))
         self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
 >>>>>>> work on unit tests
+=======
+        # Testing that summary flags return correctly
+        self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
+>>>>>>> add summary flag for status output

--- a/test/tests/status_cmd_tests.py
+++ b/test/tests/status_cmd_tests.py
@@ -122,6 +122,13 @@ class StatusCmdTests(PavTestCase):
         args = parser.parse_args(arg_list)
         self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
 
+        parser = argparse.ArgumentParser()
+        status_cmd._setup_arguments(parser)
+        arg_list = ['-s'] + test_str.split()
+        args = parser.parse_args(arg_list)
+        self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
+
+
     def test_set_status_command(self):
         """Test set status command by generating a suite of tests."""
 
@@ -226,6 +233,7 @@ class StatusCmdTests(PavTestCase):
 
         # TODO: Test that the above have actually been set.
 
+<<<<<<< HEAD
     def test_history_status(self):
         """Checks pav status --history $id command when
         passed a valid and invalid test id.
@@ -240,6 +248,49 @@ class StatusCmdTests(PavTestCase):
         test_cfg3['name'] = 'test3'
 
         configs = [test_cfg1, test_cfg2, test_cfg3]
+=======
+    def goober_test_status_summary(self):
+        # Testing that status works with summary flag
+        config1 = file_format.TestConfigLoader().validate({
+            'scheduler': 'raw',
+            'run': {
+                'env': {
+                    'foo': 'bar',
+                },
+                'cmds': ['echo "I $foo, punks"'],
+            },
+        })
+
+        config1['name'] = 'run_test0'
+
+        config2 = file_format.TestConfigLoader().validate({
+            'scheduler': 'raw',
+            'run': {
+                'env': {
+                    'too': 'tar',
+                },
+                'cmds': ['echo "I $too, punks"'],
+            },
+        })
+
+        config2['name'] = 'run_test1'
+
+        config3 = file_format.TestConfigLoader().validate({
+            'scheduler': 'raw',
+            'run': {
+                'env': {
+                    'too': 'tar',
+                },
+                'cmds': ['sleep 10'],
+            },
+        })
+
+        config3['name'] = 'run_test2'
+
+        configs = [config1, config2, config3]
+
+        var_man = VariableSetManager()
+>>>>>>> work on unit tests
 
         tests = [TestRun(self.pav_cfg, test)
                  for test in configs]
@@ -247,6 +298,7 @@ class StatusCmdTests(PavTestCase):
         for test in tests:
             test.RUN_SILENT_TIMEOUT = 1
 
+<<<<<<< HEAD
         suite = TestSeries(self.pav_cfg, tests)
         test_str = " ".join([str(test) for test in suite.tests])
         status_cmd = commands.get_command('status')
@@ -267,3 +319,22 @@ class StatusCmdTests(PavTestCase):
         # None int arguments "pav status --history lolol" throw
         # error in unit-test but are caught cleanly in pav usage
         # check.
+=======
+        # Make sure this doesn't explode
+        suite = TestSeries(self.pav_cfg, tests)
+        test_str = " ".join([str(test) for test in suite.tests])
+
+        status_cmd = commands.get_command('status')
+        status_cmd.outfile = io.StringIO()
+
+
+
+        #for test in suite.tests:
+        print()
+        parser = argparse.ArgumentParser()
+        status_cmd._setup_arguments(parser)
+        arg_list = ['-s']
+        args = parser.parse_args(arg_list)
+        print(status_cmd.run(self.pav_cfg, args))
+        self.assertEqual(status_cmd.run(self.pav_cfg, args), 0)
+>>>>>>> work on unit tests


### PR DESCRIPTION
Status summary command. Usage looks like `pav status -s` or `pav status --summary`
Open to stylistic changes as this is a first draft. If you feeling strongly on adding more or less categories let me know! Output looks like: 

<img width="418" alt="Screen Shot 2020-05-26 at 1 23 23 PM" src="https://user-images.githubusercontent.com/35508425/82941727-1b299280-9f54-11ea-8638-9e15f1adaa80.png">

Somethings to note right off the bat. The columns `passed` `failed` only apply to the `COMPLETED` row. Adding `n/a` or `none` to the other rows makes it look cluttered. Also I'm undecided on whether it should be titled `passed (of completed)` and `failed (of completed)` also having the total values not the percents such as `passed | 50% (10/20) |` etc. 

Still working on the possibility of a "animated progress bar" If that's something people want. 