### PR TITLE
Various fixes to master based on real usage.

### DIFF
--- a/lib/pavilion/plugins/commands/result.py
+++ b/lib/pavilion/plugins/commands/result.py
@@ -85,7 +85,13 @@ class ResultsCommand(commands.Command):
                 return errno.EINVAL
 
         if args.json or args.full:
-            results = {test.name: test.results for test in tests}
+            if len(tests) > 1:
+                results = {test.name: test.results for test in tests}
+            else:
+                # There should always be at least one test
+                results = tests[0].results
+
+
             try:
                 if args.json:
                     output.json_dump(results, self.outfile)

--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -7,11 +7,10 @@ import time
 import threading
 from collections import defaultdict
 
-import pavilion.result
 from pavilion import commands
 from pavilion import output
 from pavilion.output import fprint
-from pavilion.result import parsers
+from pavilion import result
 from pavilion import schedulers
 from pavilion import system_variables
 from pavilion import test_config
@@ -442,15 +441,15 @@ name) of lists of tuples
 
             # Make sure the result parsers have reasonable arguments.
             try:
-                pavilion.result.check_config(test.config['results'])
-            except TestRunError as err:
-                rp_errors.append(str(err))
+                result.check_config(test.config['results'])
+            except result.ResultError as err:
+                rp_errors.append((test, str(err)))
 
         if rp_errors:
             fprint("Result Parser configurations had errors:",
                    file=self.errfile, color=output.RED)
-            for msg in rp_errors:
-                fprint(msg, bullet=' - ', file=self.errfile)
+            for test, msg in rp_errors:
+                fprint(test.name, '-', msg, file=self.errfile)
             return errno.EINVAL
 
         return 0

--- a/lib/pavilion/result/__init__.py
+++ b/lib/pavilion/result/__init__.py
@@ -8,6 +8,7 @@ from pavilion.test_config import resolver
 from .evaluations import check_expression, evaluate_results
 from .base import base_results, ResultError, BASE_RESULTS
 from .parsers import parse_results, ResultParser, get_plugin
+from . import parsers
 
 
 def check_config(result_configs):
@@ -36,6 +37,8 @@ For evaluations we check for:
     for rtype in parser_conf:
         for rconf in parser_conf[rtype]:
             key = rconf.get('key')
+            action = rconf.get('action')
+            per_file = rconf.get('per_file')
 
             # Don't check args if they have deferred values.
             for values in rconf.values():
@@ -62,16 +65,31 @@ For evaluations we check for:
                     .format(key, rtype)
                 )
 
-            if key in BASE_RESULTS.keys() or key == 'result':
+            if key in BASE_RESULTS.keys():
                 raise ResultError(
                     "Result parser key '{}' under parser '{}' is reserved."
                     .format(key, rtype)
                 )
 
+            if (key == 'result' 
+                    and action not in (parsers.ACTION_TRUE, 
+                                       parsers.ACTION_FALSE)
+                    and per_file not in (parsers.PER_FIRST, parsers.PER_LAST,
+                                         parsers.PER_ANY, parsers.PER_ALL)):
+                raise ResultError(
+                    "Result parser has key 'result', but must store a "
+                    "boolean. Use action 'first' or 'last', along with a "
+                    "per_file setting of 'first', 'last', 'any', or 'all'")
+
             key_names.append(key)
 
             parser = get_plugin(rtype)
-            parser.check_args(**rconf)
+            try:
+                parser.check_args(**rconf)
+            except ResultError as err: 
+                raise ResultError(
+                    "Key '{}': {}".format(key, err.args[0]))
+
 
         for key, expr in evaluate_conf.items():
             if key in BASE_RESULTS:

--- a/lib/pavilion/test_config/file_format.py
+++ b/lib/pavilion/test_config/file_format.py
@@ -16,7 +16,8 @@ class TestConfigError(ValueError):
 TEST_NAME_RE_STR = r'^[a-zA-Z_][a-zA-Z0-9_-]*$'
 TEST_NAME_RE = re.compile(TEST_NAME_RE_STR)
 KEY_NAME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_-]*$')
-VAR_NAME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_-]*[?+]?$')
+VAR_KEY_NAME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_]*$')
+VAR_NAME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_]*[?+]?$')
 
 
 class PathCategoryElem(yc.CategoryElem):
@@ -33,7 +34,7 @@ class VariableElem(yc.CategoryElem):
     normalization of these values.
     """
 
-    _NAME_RE = KEY_NAME_RE
+    _NAME_RE = VAR_KEY_NAME_RE
 
     def __init__(self, name=None, **kwargs):
         """Just like a CategoryElem, but the sub_elem must be a StrElem

--- a/lib/pavilion/test_config/resolver.py
+++ b/lib/pavilion/test_config/resolver.py
@@ -613,9 +613,9 @@ class TestConfigResolver:
         # generally means there are cycles in our dependency tree.
         if depended_on_by:
             raise TestConfigError(
-                "Tests in suite '{}' have dependencies on '{}' that "
+                "Tests in suite '{}' have dependencies on {} that "
                 "could not be resolved."
-                .format(suite_path, depended_on_by.keys()))
+                .format(suite_path, tuple(depended_on_by.keys())))
 
         # Remove the test base
         del suite_tests['__base__']

--- a/lib/pavilion/test_config/variables.py
+++ b/lib/pavilion/test_config/variables.py
@@ -641,7 +641,7 @@ index, sub_var) tuple.
         var_man = VariableSetManager()
 
         var_man.variable_sets = copy.deepcopy(self.variable_sets)
-        var_man.deferred = self.deferred
+        var_man.deferred = copy.deepcopy(self.deferred)
 
         return var_man
 

--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -771,7 +771,7 @@ of result keys.
         if not regather:
             self.status.set(STATES.RESULTS,
                             "Performing {} result evaluations."
-                            .format(self.config['results']['evaluate']))
+                            .format(len(self.config['results']['evaluate'])))
         try:
             result.evaluate_results(
                 results,


### PR DESCRIPTION
 - The results --full/--json command print results for a single test
   by themselves, not as a single item dict.
 - Improved result parser error handling and reporting
 - You can store to the 'result' key again with result parsers, but it
   must be a boolean result.
 - Variable names can no longer contain hypens. This is now enforced at the
   config level.
 - Fixed var_man.deferred copying problem, again.