### PR TITLE
WIP: Add in_place build functionality... hopefully.

### DIFF
--- a/lib/pavilion/builder.py
+++ b/lib/pavilion/builder.py
@@ -411,7 +411,10 @@ class TestBuilder:
                     self.tracker.update(
                         state=STATES.BUILDING,
                         note="Starting build {}.".format(self.name))
-                    build_dir = self.path.with_suffix('.tmp')
+                    if not self._config.get('in_place'):
+                        build_dir = self.path.with_suffix('.tmp')
+                    else:
+                        build_dir = self.path
 
                     # Attempt to perform the actual build, this shouldn't
                     # raise an exception unless something goes terribly
@@ -441,7 +444,8 @@ class TestBuilder:
                         utils.repair_symlinks(build_dir)
 
                         # Rename the build to it's final location.
-                        build_dir.rename(self.path)
+                        if not self._config.get('in_place'):
+                            build_dir.rename(self.path)
                     except (OSError, ValueError) as err:
                         self.tracker.error(
                             "Unexpected error: {}".format(err.args[0])

--- a/lib/pavilion/test_config/file_format.py
+++ b/lib/pavilion/test_config/file_format.py
@@ -256,6 +256,11 @@ expected to be added to by various plugins.
                               'Relative paths searched for in ~/.pavilion, '
                               '$PAV_CONFIG. Absolute paths are ok, '
                               'but not recommended.'),
+                yc.StrElem(
+                    'in_place', default='False',
+                    choices=['true', 'false', 'True', 'False'],
+                    help_text="Whether to build in the final location or "
+                              "in a temporary directory and then moved."),
                 yc.ListElem(
                     'modules', sub_elem=yc.StrElem(),
                     help_text="Modules to load into the build environment."),

--- a/test/tests/builder_tests.py
+++ b/test/tests/builder_tests.py
@@ -326,6 +326,23 @@ class BuilderTests(PavTestCase):
         self.assertTrue(current_note.startswith(
             "Build returned a non-zero result."))
 
+    def test_in_place_build(self):
+        """Check if the in_place functionality works."""
+
+        config = {
+            'name': 'build_test',
+            'scheduler': 'raw',
+            'build': {
+                'cmds': ['sleep 10'],
+                'in_place': 'true',
+            },
+        }
+
+        #  Check that building, and then re-using, a build directory works.
+        test = TestRun(self.pav_cfg, config)
+
+        self.assertFalse(self.tmp_path.exists())
+
     def test_builder_cancel(self):
         """Check build canceling through their threading event."""
 


### PR DESCRIPTION
Trying to add the ability to specify that a test should be built in the final location instead of a temporary file and moved to the final location.  This has become necessary when integrating tests that integrate the build location into the test in a way that makes it non-portable.  Outlined in #250 .

The current implementation idea is just to add a key under the build section of a test 'in_place' that modifies the behavior of the builder class to not add `.tmp` to the end of the build directory (likewise skipping the step to move it to the final location).