### PR TITLE
Pass shared_group to script composer.

### DIFF
--- a/lib/pavilion/schedulers.py
+++ b/lib/pavilion/schedulers.py
@@ -473,7 +473,8 @@ class SchedulerPlugin(IPlugin.IPlugin):
         script = scriptcomposer.ScriptComposer(
             header=header,
             details=scriptcomposer.ScriptDetails(
-                path=self._kickoff_script_path(test_obj)
+                path=self._kickoff_script_path(test_obj),
+                group=pav_cfg.shared_group
             ),
         )
 


### PR DESCRIPTION
I ran into issues on a system where the group did not match the user. I believe specifying the `shared_group` in the config should have corrected this but I ended up seeing"

```
Unknown error running command run: Group cschisd not found on this machine..
Traceback (most recent call last):
    ...
    raise ScriptComposerError(error)
pavilion.scriptcomposer.ScriptComposerError: Group cschisd not found on this machine.
```

This PR seeks to address this.

From what I could tell the use of `pav_cfg.shared_group` should be acceptable since a `None` value found in an undefined config should be accounted for. Though please let me know if I'm missing something.