### PR TITLE
pushed up the point of _get_skip to call before build

### DIFF
--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -149,11 +149,7 @@ class RunCommand(commands.Command):
             self._complete_tests(all_tests)
             return res
 
-        runnable_test = []
-        for test in all_tests:
-            if not test.skipped:
-                runnable_test.append(test)
-        all_tests = runnable_test
+        all_tests = [test for test in all_tests if not test.skipped]
 
         res = self.build_local(
             tests=all_tests,

--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -149,6 +149,12 @@ class RunCommand(commands.Command):
             self._complete_tests(all_tests)
             return res
 
+        runnable_tests = []
+        for test in all_tests:
+            if not test.skipped:
+                runnable_tests.append(test)
+        all_tests = runnable_tests
+
         res = self.build_local(
             tests=all_tests,
             max_threads=pav_cfg.build_threads,

--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -201,15 +201,6 @@ class RunCommand(commands.Command):
         """
 
         all_tests = sum(tests_by_sched.values(), [])
-        #from pavilion.output import dbg_print
-        #dbg_print(len(all_tests))
-        #runnable_tests = []
-        #for test in all_tests:
-        #    if not test.skipped:
-        #        runnable_tests.append(test)
-        #all_tests = runnable_tests
-        #dbg_print(all_tests)
-
 
         for sched_name in tests_by_sched.keys():
             sched = schedulers.get_plugin(sched_name)
@@ -225,8 +216,8 @@ class RunCommand(commands.Command):
             tests = [test for test in tests if not test.skipped]
             sched = schedulers.get_plugin(sched_name)
 
-            # Filter out any 'build_only' or 'SKIPPED' tests
-            # (it should be all or none) that shouldn't be scheduled.
+            # Filter out any 'build_only' tests (it should be all or none)
+            # that shouldn't be scheduled.
             tests = [test for test in tests if
                      # The non-build only tests
                      (not test.build_only) or

--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -149,11 +149,11 @@ class RunCommand(commands.Command):
             self._complete_tests(all_tests)
             return res
 
-        runnable_tests = []
+        runnable_test = []
         for test in all_tests:
             if not test.skipped:
-                runnable_tests.append(test)
-        all_tests = runnable_tests
+                runnable_test.append(test)
+        all_tests = runnable_test
 
         res = self.build_local(
             tests=all_tests,
@@ -201,6 +201,15 @@ class RunCommand(commands.Command):
         """
 
         all_tests = sum(tests_by_sched.values(), [])
+        #from pavilion.output import dbg_print
+        #dbg_print(len(all_tests))
+        #runnable_tests = []
+        #for test in all_tests:
+        #    if not test.skipped:
+        #        runnable_tests.append(test)
+        #all_tests = runnable_tests
+        #dbg_print(all_tests)
+
 
         for sched_name in tests_by_sched.keys():
             sched = schedulers.get_plugin(sched_name)
@@ -216,8 +225,8 @@ class RunCommand(commands.Command):
             tests = [test for test in tests if not test.skipped]
             sched = schedulers.get_plugin(sched_name)
 
-            # Filter out any 'build_only' tests (it should be all or none)
-            # that shouldn't be scheduled.
+            # Filter out any 'build_only' or 'SKIPPED' tests
+            # (it should be all or none) that shouldn't be scheduled.
             tests = [test for test in tests if
                      # The non-build only tests
                      (not test.build_only) or

--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -229,6 +229,8 @@ class TestRun:
                 self.status.set(STATES.CREATED,
                                 "Test directory and status file created.")
 
+        self.skipped = self._get_skipped()  # eval skip.
+
         self.run_timeout = self.parse_timeout(
             'run', config.get('run', {}).get('timeout'))
         self.build_timeout = self.parse_timeout(
@@ -292,7 +294,6 @@ class TestRun:
         self._results = None
         self._created = None
 
-        self.skipped = self._get_skipped()
 
     @classmethod
     def load(cls, pav_cfg, test_id):

--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -293,8 +293,6 @@ class TestRun:
         self._created = None
 
         self.skipped = self._get_skipped()  # eval skip.
-        if self.skipped:
-            return None
 
     @classmethod
     def load(cls, pav_cfg, test_id):
@@ -437,7 +435,10 @@ class TestRun:
         :returns: True if build successful
         """
         if self.skipped:
-            return False
+            raise RuntimeError(
+                "This test is set to skip and shouldn't be building."
+                .format(s=self))
+
         if self.build_origin_path.exists():
             raise RuntimeError(
                 "Whatever called build() is calling it for a second time."
@@ -499,7 +500,9 @@ class TestRun:
             future.
         """
         if self.skipped:
-            return False
+            raise RuntimeError(
+                "This test is set to skip and shouldn't be running."
+                .format(s=self))
 
         if self.build_only:
             self.status.set(
@@ -995,7 +998,7 @@ directory that doesn't already exist.
     def _get_skipped(self):
         """Kicks off assessing if current test is skipped."""
         if self.status.current().state == 'SKIPPED':
-            #Skip has already been evaluated.
+            # Skip has already been evaluated.
             return True
         else:
             skip_reason_list = self._evaluate_skip_conditions()

--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -137,7 +137,7 @@ class TestRun:
         self._attrs = {}
 
         # Mark the run to build locally.
-        self.build_local = config.get('build', {})\
+        self.build_local = config.get('build', {}) \
                                  .get('on_nodes', 'false').lower() != 'true'
 
         # If a test access group was given, make sure it exists and the
@@ -435,11 +435,6 @@ class TestRun:
         :returns: True if build successful
         """
 
-        #if self.skipped:
-        #    raise RuntimeError(
-        #        "This test is set to skip and shouldn't be building."
-        #        .format(s=self))
-
         if self.build_origin_path.exists():
             raise RuntimeError(
                 "Whatever called build() is calling it for a second time."
@@ -500,10 +495,6 @@ class TestRun:
         :raises TestRunError: We don't actually raise this, but might in the
             future.
         """
-        #if self.skipped:
-        #    raise RuntimeError(
-        #       "This test is set to skip and shouldn't be running."
-        #        .format(s=self))
 
         if self.build_only:
             self.status.set(

--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -434,10 +434,11 @@ class TestRun:
 
         :returns: True if build successful
         """
-        if self.skipped:
-            raise RuntimeError(
-                "This test is set to skip and shouldn't be building."
-                .format(s=self))
+
+        #if self.skipped:
+        #    raise RuntimeError(
+        #        "This test is set to skip and shouldn't be building."
+        #        .format(s=self))
 
         if self.build_origin_path.exists():
             raise RuntimeError(
@@ -499,10 +500,10 @@ class TestRun:
         :raises TestRunError: We don't actually raise this, but might in the
             future.
         """
-        if self.skipped:
-            raise RuntimeError(
-                "This test is set to skip and shouldn't be running."
-                .format(s=self))
+        #if self.skipped:
+        #    raise RuntimeError(
+        #       "This test is set to skip and shouldn't be running."
+        #        .format(s=self))
 
         if self.build_only:
             self.status.set(


### PR DESCRIPTION
Nick pointed out a serious problem of tests that should skip but are failing instead. This is due to commands in the build section of the tests running before it evaluates the skip. For example the build section might say load some cray library. This will fail on TOSS before skip is called. 

I moved where skip is being called to the earliest part of the `__init__` in test_run.py. Hopefully this will work and if not some serious rework is required, yikes...