### PR TITLE
Run cmd dictionary to list

### DIFF
--- a/lib/pavilion/cmd_utils.py
+++ b/lib/pavilion/cmd_utils.py
@@ -3,12 +3,22 @@ multiple commands."""
 
 from pavilion import dir_db
 from pavilion.series import TestSeries, TestSeriesError
-from pavilion.test_run import TestAttributes
+from pavilion.test_run import TestAttributes, TestConfigError, TestRunError, TestRun
+from pavilion.builder import MultiBuildTracker
+from pavilion.status_file import STATES
 from pavilion import filters
+from pavilion import test_config
+from pavilion import commands
+from pavilion import output
 
 import argparse
+import pathlib
+import threading
+import time
+import errno
 from typing import List
 from pathlib import Path
+from collections import defaultdict
 
 
 def arg_filtered_tests(pav_cfg, args: argparse.Namespace) -> List[int]:
@@ -118,3 +128,260 @@ def test_list_to_paths(pav_cfg, req_tests) -> List[Path]:
             test_paths.append(test_dir)
 
     return test_paths
+
+
+def get_test_configs(pav_cfg, host, test_files, tests, modes,
+                     overrides, logger=None, outfile=None):
+    """Translate a general set of pavilion test configs into the final,
+    resolved configurations. These objects will be organized in a
+    dictionary by scheduler, and have a scheduler object instantiated and
+    attached.
+    :param pav_cfg: The pavilion config
+    :param str host: The host config to target these tests with
+    :param list(str) modes: The mode configs to use.
+    :param list(Path) test_files: Files containing a newline separated
+        list of tests.
+    :param list(str) tests: The tests to run.
+    :param list(str) overrides: Overrides to apply to the configurations.
+name) of lists of tuples
+        test configs and their variable managers.
+    """
+    logger.debug("Finding Configs")
+
+    resolver = test_config.TestConfigResolver(pav_cfg)
+
+    tests = list(tests)
+    for file in test_files:
+        try:
+            with pathlib.PosixPath(file).open() as test_file:
+                for line in test_file.readlines():
+                    line = line.strip()
+                    if line and not line.startswith('#'):
+                        tests.append(line)
+        except (OSError, IOError) as err:
+            msg = "Could not read test file {}: {}".format(file, err)
+            logger.error(msg)
+            raise commands.CommandError(msg)
+
+    try:
+        resolved_cfgs = resolver.load(
+            tests,
+            host,
+            modes,
+            overrides,
+            output_file=outfile,
+        )
+    except TestConfigError as err:
+        raise commands.CommandError(err.args[0])
+
+    tests_by_scheduler = defaultdict(lambda: [])
+    for cfg, var_man in resolved_cfgs:
+        tests_by_scheduler[cfg['scheduler']].append((cfg, var_man))
+
+    return tests_by_scheduler
+
+
+def configs_to_tests(pav_cfg, configs_by_sched, mb_tracker=None,
+                     build_only=False, rebuild=False, outfile=None):
+    """Convert the dictionary of test configs by scheduler into actual
+    tests.
+
+    :param pav_cfg: The Pavilion config
+    :param dict[str,list] configs_by_sched: A dictionary of lists of test
+    configs.
+    :param Union[MultiBuildTracker,None] mb_tracker: The build tracker.
+    :param bool build_only: Whether to only build these tests.
+    :param bool rebuild: After figuring out what build to use, rebuild it.
+    :return:
+    """
+
+    tests_by_sched = {}
+    progress = 0
+    tot_tests = sum([len(tests) for tests in configs_by_sched.values()])
+
+    for sched_name in configs_by_sched.keys():
+        tests_by_sched[sched_name] = []
+        try:
+            for i in range(len(configs_by_sched[sched_name])):
+                cfg, var_man = configs_by_sched[sched_name][i]
+                tests_by_sched[sched_name].append(TestRun(
+                    pav_cfg=pav_cfg,
+                    config=cfg,
+                    var_man=var_man,
+                    build_tracker=mb_tracker,
+                    build_only=build_only,
+                    rebuild=rebuild,
+                ))
+                progress += 1.0/tot_tests
+                if outfile is not None:
+                    output.fprint("Creating Test Runs: {:.0%}".format(progress),
+                                  file=outfile, end='\r')
+        except (TestRunError, TestConfigError) as err:
+            raise commands.CommandError(err)
+
+    if outfile is not None:
+        output.fprint('', file=outfile)
+
+    return tests_by_sched
+
+
+def build_local(tests, max_threads, mb_tracker, build_verbosity, outfile=None, errfile=None):
+    """Build all tests that request for their build to occur on the
+    kickoff host.
+
+    :param list[TestRun] tests: The list of tests to potentially build.
+    :param int max_threads: Maximum number of build threads to start.
+    :param int build_verbosity: How much info to print during building.
+        See the -b/--build-verbose argument for more info.
+    :param MultiBuildTracker mb_tracker: The tracker for all builds.
+    """
+
+    BUILD_STATUS_PREAMBLE = '{when:20s} {test_id:6} {state:{state_len}s}'
+    BUILD_SLEEP_TIME = 0.1
+
+    test_threads = []   # type: List[Union[threading.Thread, None]]
+    remote_builds = []
+
+    cancel_event = threading.Event()
+
+    # Generate new build names for each test that is rebuilding.
+    # We do this here, even for non_local tests, because otherwise the
+    # non-local tests can't tell what was built fresh either on a
+    # front-end or by other tests rebuilding on nodes.
+    for test in tests:
+        if test.rebuild and test.builder.exists():
+            test.builder.deprecate()
+            test.builder.rename_build()
+            test.build_name = test.builder.name
+            test.save_attributes()
+
+    # We don't want to start threads that are just going to wait on a lock,
+    # so we'll rearrange the builds so that the uniq build names go first.
+    # We'll use this as a stack, so tests that should build first go at
+    # the end of the list.
+    build_order = []
+    # If we've seen a build name, the build can go later.
+    seen_build_names = set()
+
+    for test in tests:
+        if not test.build_local:
+            remote_builds.append(test)
+        elif test.builder.name not in seen_build_names:
+            build_order.append(test)
+            seen_build_names.add(test.builder.name)
+        else:
+            build_order.insert(0, test)
+
+    # Keep track of what the last message printed per build was.
+    # This is for double build verbosity.
+    message_counts = {test.id: 0 for test in tests}
+
+    # Used to track which threads are for which tests.
+    test_by_threads = {}
+
+    if build_verbosity > 0:
+        output.fprint(BUILD_STATUS_PREAMBLE
+                      .format(when='When', test_id='TestID',
+                      state_len=STATES.max_length, state='State'),
+                      'Message', file=outfile, width=None)
+
+    builds_running = 0
+    # Run and track <max_threads> build threads, giving output according
+    # to the verbosity level. As threads finish, new ones are started until
+    # either all builds complete or a build fails, in which case all tests
+    # are aborted.
+    while build_order or test_threads:
+        # Start a new thread if we haven't hit our limit.
+        if build_order and builds_running < max_threads:
+            test = build_order.pop()
+
+            test_thread = threading.Thread(
+                target=test.build,
+                args=(cancel_event,)
+            )
+            test_threads.append(test_thread)
+            test_by_threads[test_thread] = test
+            test_thread.start()
+
+        # Check if all our threads are alive, and join those that aren't.
+        for i in range(len(test_threads)):
+            thread = test_threads[i]
+            if not thread.is_alive():
+                thread.join()
+                builds_running -= 1
+                test_threads[i] = None
+                test = test_by_threads[thread]
+                del test_by_threads[thread]
+
+                # Only output test status after joining a thread.
+                if build_verbosity == 1:
+                    notes = mb_tracker.get_notes(test.builder)
+                    when, state, msg = notes[-1]
+                    when = output.get_relative_timestamp(when)
+                    preamble = (BUILD_STATUS_PREAMBLE
+                                .format(when=when, test_id=test.id,
+                                        state_len=STATES.max_length,
+                                        state=state))
+                    output.fprint(preamble, msg, wrap_indent=len(preamble),
+                                  file=outfile, width=None)
+
+        test_threads = [thr for thr in test_threads if thr is not None]
+
+        if cancel_event.is_set():
+            for thread in test_threads:
+                thread.join()
+
+            for test in tests:
+                if (test.status.current().state not in
+                        (STATES.BUILD_FAILED, STATES.BUILD_ERROR)):
+                    test.status.set(
+                        STATES.ABORTED,
+                        "Run aborted due to failures in other builds.")
+
+            output.fprint("Build error while building tests. Cancelling runs.",
+                          color=output.RED, file=outfile, clear=True)
+            output.fprint("Failed builds are placed in <working_dir>/test_runs/"
+                          "<test_id>/build for the corresponding test run.",
+                          color=output.CYAN, file=outfile)
+
+            for failed_build in mb_tracker.failures():
+                output.fprint("Build error for test {f.test.name} (#{f.test.id})."
+                              .format(f=failed_build), file=errfile)
+                output.fprint("See test status file (pav cat {id} status) and/or "
+                              "the test build log (pav log build {id})"
+                              .format(id=failed_build.test.id), file=errfile)
+
+            return errno.EINVAL
+
+        state_counts = mb_tracker.state_counts()
+        if build_verbosity == 0:
+            # Print a self-clearing one-liner of the counts of the
+            # build statuses.
+            parts = []
+            for state in sorted(state_counts.keys()):
+                parts.append("{}: {}".format(state, state_counts[state]))
+            line = ' | '.join(parts)
+            output.fprint(line, end='\r', file=outfile, width=None,
+                          clear=True)
+        elif build_verbosity > 1:
+            for test in tests:
+                seen = message_counts[test.id]
+                msgs = mb_tracker.messages[test.builder][seen:]
+                for when, state, msg in msgs:
+                    when = output.get_relative_timestamp(when)
+                    state = '' if state is None else state
+                    preamble = BUILD_STATUS_PREAMBLE.format(
+                        when=when, test_id=test.id,
+                        state_len=STATES.max_length, state=state)
+
+                    output.fprint(preamble, msg, wrap_indent=len(preamble),
+                                  file=outfile, width=None)
+                message_counts[test.id] += len(msgs)
+
+        time.sleep(BUILD_SLEEP_TIME)
+
+    if build_verbosity == 0:
+        # Print a newline after our last status update.
+        output.fprint(width=None, file=outfile)
+
+    return 0

--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -13,6 +13,7 @@ from pavilion import output
 from pavilion import result
 from pavilion import schedulers
 from pavilion import test_config
+from pavilion import cmd_utils
 from pavilion.builder import MultiBuildTracker
 from pavilion.output import fprint
 from pavilion.plugins.commands.status import print_from_tests
@@ -151,11 +152,13 @@ class RunCommand(commands.Command):
 
         all_tests = [test for test in all_tests if not test.skipped]
 
-        res = self.build_local(
+        res = cmd_utils.build_local(
             tests=all_tests,
             max_threads=pav_cfg.build_threads,
             mb_tracker=mb_tracker,
-            build_verbosity=args.build_verbosity)
+            build_verbosity=args.build_verbosity,
+            outfile=self.outfile,
+            errfile=self.errfile)
         if res != 0:
             self._complete_tests(all_tests)
             return res
@@ -282,100 +285,6 @@ class RunCommand(commands.Command):
 
         return 0
 
-    def _get_test_configs(self, pav_cfg, host, test_files, tests, modes,
-                          overrides):
-        """Translate a general set of pavilion test configs into the final,
-        resolved configurations. These objects will be organized in a
-        dictionary by scheduler, and have a scheduler object instantiated and
-        attached.
-        :param pav_cfg: The pavilion config
-        :param str host: The host config to target these tests with
-        :param list(str) modes: The mode configs to use.
-        :param list(Path) test_files: Files containing a newline separated
-            list of tests.
-        :param list(str) tests: The tests to run.
-        :param list(str) overrides: Overrides to apply to the configurations.
-name) of lists of tuples
-            test configs and their variable managers.
-        """
-        self.logger.debug("Finding Configs")
-
-        resolver = test_config.TestConfigResolver(pav_cfg)
-
-        tests = list(tests)
-        for file in test_files:
-            try:
-                with pathlib.PosixPath(file).open() as test_file:
-                    for line in test_file.readlines():
-                        line = line.strip()
-                        if line and not line.startswith('#'):
-                            tests.append(line)
-            except (OSError, IOError) as err:
-                msg = "Could not read test file {}: {}".format(file, err)
-                self.logger.error(msg)
-                raise commands.CommandError(msg)
-
-        try:
-            resolved_cfgs = resolver.load(
-                tests,
-                host,
-                modes,
-                overrides,
-                output_file=self.outfile,
-            )
-        except TestConfigError as err:
-            raise commands.CommandError(err.args[0])
-
-        tests_by_scheduler = defaultdict(lambda: [])
-        for cfg, var_man in resolved_cfgs:
-            tests_by_scheduler[cfg['scheduler']].append((cfg, var_man))
-
-        return tests_by_scheduler
-
-    @staticmethod
-    def _configs_to_tests(pav_cfg, configs_by_sched, mb_tracker=None,
-                          build_only=False, rebuild=False, outfile=None):
-        """Convert the dictionary of test configs by scheduler into actual
-        tests.
-
-        :param pav_cfg: The Pavilion config
-        :param dict[str,list] configs_by_sched: A dictionary of lists of test
-        configs.
-        :param Union[MultiBuildTracker,None] mb_tracker: The build tracker.
-        :param bool build_only: Whether to only build these tests.
-        :param bool rebuild: After figuring out what build to use, rebuild it.
-        :return:
-        """
-
-        tests_by_sched = {}
-        progress = 0
-        tot_tests = sum([len(tests) for tests in configs_by_sched.values()])
-
-        for sched_name in configs_by_sched.keys():
-            tests_by_sched[sched_name] = []
-            try:
-                for i in range(len(configs_by_sched[sched_name])):
-                    cfg, var_man = configs_by_sched[sched_name][i]
-                    tests_by_sched[sched_name].append(TestRun(
-                        pav_cfg=pav_cfg,
-                        config=cfg,
-                        var_man=var_man,
-                        build_tracker=mb_tracker,
-                        build_only=build_only,
-                        rebuild=rebuild,
-                    ))
-                    progress += 1.0/tot_tests
-                    if outfile is not None:
-                        fprint("Creating Test Runs: {:.0%}".format(progress),
-                               file=outfile, end='\r')
-            except (TestRunError, TestConfigError) as err:
-                raise commands.CommandError(err)
-
-        if outfile is not None:
-            fprint('', file=outfile)
-
-        return tests_by_sched
-
     def _get_tests(self, pav_cfg, args, mb_tracker, build_only=False,
                    local_builds_only=False):
         """Turn the test run arguments into actual TestRun objects.
@@ -391,12 +300,14 @@ name) of lists of tuples
         """
 
         try:
-            configs_by_sched = self._get_test_configs(pav_cfg=pav_cfg,
-                                                      host=args.host,
-                                                      test_files=args.files,
-                                                      tests=args.tests,
-                                                      modes=args.modes,
-                                                      overrides=args.overrides)
+            configs_by_sched = cmd_utils.get_test_configs(pav_cfg=pav_cfg,
+                                                          host=args.host,
+                                                          test_files=args.files,
+                                                          tests=args.tests,
+                                                          modes=args.modes,
+                                                          overrides=args.overrides,
+                                                          logger=self.logger,
+                                                          outfile=self.outfile)
 
             # Remove non-local builds when doing only local builds.
             if build_only and local_builds_only:
@@ -410,7 +321,7 @@ name) of lists of tuples
                                   if cfg is not None]
                     configs_by_sched[sched] = sched_cfgs
 
-            tests_by_sched = self._configs_to_tests(
+            tests_by_sched = cmd_utils.configs_to_tests(
                 pav_cfg=pav_cfg,
                 configs_by_sched=configs_by_sched,
                 mb_tracker=mb_tracker,
@@ -467,166 +378,3 @@ name) of lists of tuples
 
         return 0
 
-    BUILD_STATUS_PREAMBLE = '{when:20s} {test_id:6} {state:{state_len}s}'
-    BUILD_SLEEP_TIME = 0.1
-
-    def build_local(self, tests, max_threads, mb_tracker,
-                    build_verbosity):
-        """Build all tests that request for their build to occur on the
-        kickoff host.
-
-        :param list[TestRun] tests: The list of tests to potentially build.
-        :param int max_threads: Maximum number of build threads to start.
-        :param int build_verbosity: How much info to print during building.
-            See the -b/--build-verbose argument for more info.
-        :param MultiBuildTracker mb_tracker: The tracker for all builds.
-        """
-
-        test_threads = []   # type: List[Union[threading.Thread, None]]
-        remote_builds = []
-
-        cancel_event = threading.Event()
-
-        # Generate new build names for each test that is rebuilding.
-        # We do this here, even for non_local tests, because otherwise the
-        # non-local tests can't tell what was built fresh either on a
-        # front-end or by other tests rebuilding on nodes.
-        for test in tests:
-            if test.rebuild and test.builder.exists():
-                test.builder.deprecate()
-                test.builder.rename_build()
-                test.build_name = test.builder.name
-                test.save_attributes()
-
-        # We don't want to start threads that are just going to wait on a lock,
-        # so we'll rearrange the builds so that the uniq build names go first.
-        # We'll use this as a stack, so tests that should build first go at
-        # the end of the list.
-        build_order = []
-        # If we've seen a build name, the build can go later.
-        seen_build_names = set()
-
-        for test in tests:
-            if not test.build_local:
-                remote_builds.append(test)
-            elif test.builder.name not in seen_build_names:
-                build_order.append(test)
-                seen_build_names.add(test.builder.name)
-            else:
-                build_order.insert(0, test)
-
-        # Keep track of what the last message printed per build was.
-        # This is for double build verbosity.
-        message_counts = {test.id: 0 for test in tests}
-
-        # Used to track which threads are for which tests.
-        test_by_threads = {}
-
-        if build_verbosity > 0:
-            fprint(self.BUILD_STATUS_PREAMBLE
-                   .format(when='When', test_id='TestID',
-                           state_len=STATES.max_length, state='State'),
-                   'Message', file=self.outfile, width=None)
-
-        builds_running = 0
-        # Run and track <max_threads> build threads, giving output according
-        # to the verbosity level. As threads finish, new ones are started until
-        # either all builds complete or a build fails, in which case all tests
-        # are aborted.
-        while build_order or test_threads:
-            # Start a new thread if we haven't hit our limit.
-            if build_order and builds_running < max_threads:
-                test = build_order.pop()
-
-                test_thread = threading.Thread(
-                    target=test.build,
-                    args=(cancel_event,)
-                )
-                test_threads.append(test_thread)
-                test_by_threads[test_thread] = test
-                test_thread.start()
-
-            # Check if all our threads are alive, and join those that aren't.
-            for i in range(len(test_threads)):
-                thread = test_threads[i]
-                if not thread.is_alive():
-                    thread.join()
-                    builds_running -= 1
-                    test_threads[i] = None
-                    test = test_by_threads[thread]
-                    del test_by_threads[thread]
-
-                    # Only output test status after joining a thread.
-                    if build_verbosity == 1:
-                        notes = mb_tracker.get_notes(test.builder)
-                        when, state, msg = notes[-1]
-                        when = output.get_relative_timestamp(when)
-                        preamble = (self.BUILD_STATUS_PREAMBLE
-                                    .format(when=when, test_id=test.id,
-                                            state_len=STATES.max_length,
-                                            state=state))
-                        fprint(preamble, msg, wrap_indent=len(preamble),
-                               file=self.outfile, width=None)
-
-            test_threads = [thr for thr in test_threads if thr is not None]
-
-            if cancel_event.is_set():
-                for thread in test_threads:
-                    thread.join()
-
-                for test in tests:
-                    if (test.status.current().state not in
-                            (STATES.BUILD_FAILED, STATES.BUILD_ERROR)):
-                        test.status.set(
-                            STATES.ABORTED,
-                            "Run aborted due to failures in other builds.")
-
-                fprint("Build error while building tests. Cancelling runs.",
-                       color=output.RED, file=self.outfile, clear=True)
-                fprint("Failed builds are placed in <working_dir>/test_runs/"
-                       "<test_id>/build for the corresponding test run.",
-                       color=output.CYAN, file=self.outfile)
-
-                for failed_build in mb_tracker.failures():
-                    fprint(
-                        "Build error for test {f.test.name} (#{f.test.id})."
-                        .format(f=failed_build), file=self.errfile)
-                    fprint(
-                        "See test status file (pav cat {id} status) and/or "
-                        "the test build log (pav log build {id})"
-                        .format(id=failed_build.test.id), file=self.errfile)
-
-                return errno.EINVAL
-
-            state_counts = mb_tracker.state_counts()
-            if build_verbosity == 0:
-                # Print a self-clearing one-liner of the counts of the
-                # build statuses.
-                parts = []
-                for state in sorted(state_counts.keys()):
-                    parts.append("{}: {}".format(state, state_counts[state]))
-                line = ' | '.join(parts)
-                fprint(line, end='\r', file=self.outfile, width=None,
-                       clear=True)
-            elif build_verbosity > 1:
-                for test in tests:
-                    seen = message_counts[test.id]
-                    msgs = mb_tracker.messages[test.builder][seen:]
-                    for when, state, msg in msgs:
-                        when = output.get_relative_timestamp(when)
-                        state = '' if state is None else state
-                        preamble = self.BUILD_STATUS_PREAMBLE.format(
-                            when=when, test_id=test.id,
-                            state_len=STATES.max_length, state=state)
-
-                        fprint(preamble, msg, wrap_indent=len(preamble),
-                               file=self.outfile, width=None)
-                    message_counts[test.id] += len(msgs)
-
-            time.sleep(self.BUILD_SLEEP_TIME)
-
-        if build_verbosity == 0:
-            # Print a newline after our last status update.
-            fprint(width=None, file=self.outfile)
-
-        return 0

--- a/lib/pavilion/series.py
+++ b/lib/pavilion/series.py
@@ -3,12 +3,18 @@
 import datetime as dt
 import json
 import logging
+import errno
+import time
 from pathlib import Path
 
 from pavilion import dir_db
 from pavilion import system_variables
 from pavilion import utils
+from pavilion import schedulers
+from pavilion import output
+from pavilion.output import fprint
 from pavilion.lockfile import LockFile
+from pavilion.status_file import STATES
 from pavilion.test_run import (
     TestRun, TestRunError, TestRunNotFoundError, TestAttributes)
 
@@ -91,6 +97,94 @@ class TestSeries:
             self.path = dir_db.make_id_path(series_path, self._id)
 
         self._logger = logging.getLogger(self.LOGGER_FMT.format(self._id))
+
+    def run_tests(self, pav_cfg, wait, report_status, outfile, errfile):
+        """
+        :param pav_cfg:
+        :param int wait: Wait this long for a test to start before exiting.
+        :param bool report_status: Do a 'pav status' after tests have started.
+            on nodes, and kick them off in build only mode.
+        :param Path outfile: Direct standard output to here.
+        :param Path errfile: Direct standard error to here.
+        :return:
+        """
+
+        SLEEP_INTERVAL = 1
+
+        all_tests = list(self.tests.values())
+
+        for test in self.tests.values():
+            sched_name = test.scheduler
+            sched = schedulers.get_plugin(sched_name)
+
+            if not sched.available():
+                fprint("1 test started with the {} scheduler, but"
+                       "that scheduler isn't available on this system."
+                       .format(sched_name),
+                       file=errfile, color=output.RED)
+                return errno.EINVAL
+
+        for test in self.tests.values():
+
+            # don't run this test if it was meant to be skipped
+            if test.skipped:
+                continue
+
+            # tests that are build-only or build-local should already be completed, therefore don't run these
+            if test.complete:
+                continue
+
+            sched = schedulers.get_plugin(test.scheduler)
+            try:
+                sched.schedule_tests(pav_cfg, [test])
+            except schedulers.SchedulerPluginError as err:
+                fprint('Error scheduling test: ', file=errfile,
+                       color=output.RED)
+                fprint(err, bullet='  ', file=errfile)
+                fprint('Cancelling already kicked off tests.',
+                       file=errfile)
+                sched.cancel_job(test)
+                return errno.EINVAL
+
+        # Tests should all be scheduled now, and have the SCHEDULED state
+        # (at some point, at least). Wait until something isn't scheduled
+        # anymore (either running or dead), or our timeout expires.
+        wait_result = None
+        if wait is not None:
+            end_time = time.time() + wait
+            while time.time() < end_time and wait_result is None:
+                last_time = time.time()
+                for test in self.tests.values():
+                    sched = schedulers.get_plugin(test.scheduler)
+                    status = test.status.current()
+                    if status == STATES.SCHEDULED:
+                        status = sched.job_status(pav_cfg, test)
+
+                    if status != STATES.SCHEDULED:
+                        # The test has moved past the scheduled state
+                        wait_result = None
+                        break
+
+                if wait_result is None:
+                    # Sleep at most SLEEP INTERVAL seconds, minus the time
+                    # we spent checking our jobs.
+                    time.sleep(SLEEP_INTERVAL - (time.time() - last_time))
+
+        fprint("{} test{} started as test series {}."
+               .format(len(all_tests),
+                       's' if len(all_tests) > 1 else '',
+                       self.sid),
+               file=outfile,
+               color=output.GREEN)
+
+        if report_status:
+            from pavilion.plugins.commands.status import print_from_tests
+            return print_from_tests(
+                pav_cfg=pav_cfg,
+                tests=list(self.tests.values()),
+                outfile=outfile)
+
+        return 0
 
     @property
     def sid(self):  # pylint: disable=invalid-name

--- a/lib/pavilion/test_config/__init__.py
+++ b/lib/pavilion/test_config/__init__.py
@@ -1,4 +1,4 @@
 from . import file_format
 from .variables import DeferredVariable, VariableSetManager, VariableError
 from . import variables
-from .resolver import TestConfigError, TestConfigResolver
+from .resolver import TestConfigError, TestConfigResolver, ProtoTest

--- a/lib/pavilion/test_config/resolver.py
+++ b/lib/pavilion/test_config/resolver.py
@@ -12,8 +12,8 @@ import io
 import logging
 import os
 import re
-from collections import defaultdict
-from typing import List, IO, Tuple
+from collections import defaultdict, namedtuple
+from typing import List, IO, Dict
 
 import yc_yaml
 from pavilion import output
@@ -36,6 +36,11 @@ CONF_TEST = 'tests'
 LOGGER = logging.getLogger('pav.' + __name__)
 
 TEST_VERS_RE = re.compile(r'^\d+(\.\d+){0,2}$')
+
+
+ProtoTest = namedtuple('ProtoTest', ['config', 'var_man'])
+"""An simple object that holds the pair of a test config and its variable
+manager."""
 
 
 class TestConfigResolver:
@@ -208,10 +213,12 @@ class TestConfigResolver:
         return suites
 
     def load(self, tests: List[str], host: str = None,
-             modes: List[str] = None, overrides: List[str] = None,
+             modes: List[str] = None, overrides: Dict[str, str] = None,
              output_file: IO[str] = None) \
-            -> List[Tuple[dict, variables.VariableSetManager]]:
+            -> List[ProtoTest]:
         """Load the given tests, updated with their host and mode files.
+        Returns 'ProtoTests', a simple object with 'config' and 'var_man'
+        attributes for each resolved test.
 
         :param tests: A list of test names to load.
         :param host: The host to load tests for. Defaults to the value
@@ -219,9 +226,6 @@ class TestConfigResolver:
         :param modes: A list of modes to load.
         :param overrides: A dict of key:value pairs to apply as overrides.
         :param output_file: Where to write status output.
-
-        :returns: A list test_config dict and var_man tuples
-        :rtype: [(dict, VariableSetManager)]
         """
 
         if modes is None:
@@ -290,7 +294,7 @@ class TestConfigResolver:
 
                     raise TestConfigError(msg)
 
-                resolved_tests.append((resolved_config, pvar_man))
+                resolved_tests.append(ProtoTest(resolved_config, pvar_man))
 
             if output_file is not None:
                 progress += 1.0/len(raw_tests)

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -27,8 +27,6 @@ class RunCmdTests(PavTestCase):
             For the most part we're relying on tests of the various components
             of test_config.setup and the test_obj tests."""
 
-        run_cmd = commands.get_command('run')  # type: RunCommand
-
         test_configs = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
                                                   host='this', test_files=[],
                                                   tests=['hello_world'],
@@ -41,16 +39,12 @@ class RunCmdTests(PavTestCase):
             test_configs=test_configs,
         )
 
-        t1 = tests[0]
-        t2 = tests[1]
-        # Make sure our tests are in the right order
-        if t1.name != 'hello_world.hello':
-            t1, t2 = t2, t1
-
         # Make sure all the tests are there, under the right schedulers.
-        self.assertEqual(t1.name, 'hello_world.hello')
-        self.assertEqual(t2.name, 'hello_world.world')
-        self.assertEqual(tests[2].name, 'hello_world.narf')
+        for test in tests:
+            if test.scheduler == 'raw':
+                self.assertIn(test.name, ['hello_world.hello', 'hello_world.world'])
+            else:
+                self.assertEqual(test.name, 'hello_world.narf')
 
         tests_file = self.TEST_DATA_ROOT/'run_test_list'
 
@@ -66,8 +60,11 @@ class RunCmdTests(PavTestCase):
             test_configs=test_configs,
         )
 
-        self.assertEqual(tests[0].name, 'hello_world.world')
-        self.assertEqual(tests[1].name, 'hello_world.narf')
+        for test in tests:
+            if test.name == 'hello_world.world':
+                self.assertEqual(test.scheduler, 'raw')
+            else:
+                self.assertEqual(test.scheduler, 'dummy')
 
     def test_run(self):
 

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -30,13 +30,14 @@ class RunCmdTests(PavTestCase):
         test_configs = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
                                                   host='this', test_files=[],
                                                   tests=['hello_world'],
-                                                  modes=[], overrides={},
-                                                  logger=self.logger, outfile=sys.stdout
+                                                  modes=[],
+                                                  overrides={},
+                                                  outfile=sys.stdout
                                                   )
 
         tests = cmd_utils.configs_to_tests(
             pav_cfg=self.pav_cfg,
-            test_configs=test_configs,
+            proto_tests=test_configs,
         )
 
         # Make sure all the tests are there, under the right schedulers.
@@ -53,11 +54,11 @@ class RunCmdTests(PavTestCase):
                                                   test_files=[tests_file],
                                                   tests=[], modes=[],
                                                   overrides={},
-                                                  logger=self.logger, outfile=sys.stdout)
+                                                  outfile=sys.stdout)
 
         tests = cmd_utils.configs_to_tests(
             pav_cfg=self.pav_cfg,
-            test_configs=test_configs,
+            proto_tests=test_configs,
         )
 
         for test in tests:

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -29,19 +29,20 @@ class RunCmdTests(PavTestCase):
 
         run_cmd = commands.get_command('run')  # type: RunCommand
 
-        configs_by_sched = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
-                                                      host='this', test_files=[],
-                                                      tests=['hello_world'],
-                                                      modes=[], overrides={},
-                                                      logger=self.logger, outfile=sys.stdout
-                                                      )
+        test_configs = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
+                                                  host='this', test_files=[],
+                                                  tests=['hello_world'],
+                                                  modes=[], overrides={},
+                                                  logger=self.logger, outfile=sys.stdout
+                                                  )
 
         tests = cmd_utils.configs_to_tests(
             pav_cfg=self.pav_cfg,
-            configs_by_sched=configs_by_sched,
+            test_configs=test_configs,
         )
 
-        t1, t2 = tests['raw']
+        t1 = tests[0]
+        t2 = tests[1]
         # Make sure our tests are in the right order
         if t1.name != 'hello_world.hello':
             t1, t2 = t2, t1
@@ -49,24 +50,24 @@ class RunCmdTests(PavTestCase):
         # Make sure all the tests are there, under the right schedulers.
         self.assertEqual(t1.name, 'hello_world.hello')
         self.assertEqual(t2.name, 'hello_world.world')
-        self.assertEqual(tests['dummy'][0].name, 'hello_world.narf')
+        self.assertEqual(tests[2].name, 'hello_world.narf')
 
         tests_file = self.TEST_DATA_ROOT/'run_test_list'
 
-        configs_by_sched = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
-                                                      host='this',
-                                                      test_files=[tests_file],
-                                                      tests=[], modes=[],
-                                                      overrides={},
-                                                      logger=self.logger, outfile=sys.stdout)
+        test_configs = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
+                                                  host='this',
+                                                  test_files=[tests_file],
+                                                  tests=[], modes=[],
+                                                  overrides={},
+                                                  logger=self.logger, outfile=sys.stdout)
 
         tests = cmd_utils.configs_to_tests(
             pav_cfg=self.pav_cfg,
-            configs_by_sched=configs_by_sched,
+            test_configs=test_configs,
         )
 
-        self.assertEqual(tests['raw'][0].name, 'hello_world.world')
-        self.assertEqual(tests['dummy'][0].name, 'hello_world.narf')
+        self.assertEqual(tests[0].name, 'hello_world.world')
+        self.assertEqual(tests[1].name, 'hello_world.narf')
 
     def test_run(self):
 

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -1,10 +1,13 @@
 from pavilion import plugins
 from pavilion import commands
+from pavilion import cmd_utils
 from pavilion.unittest import PavTestCase
 from pavilion import arguments
 from pavilion.plugins.commands.run import RunCommand
 from pavilion.status_file import STATES
 import io
+import sys
+import logging
 
 
 class RunCmdTests(PavTestCase):
@@ -14,6 +17,7 @@ class RunCmdTests(PavTestCase):
         run_cmd = commands.get_command('run')
         run_cmd.outfile = io.StringIO()
         run_cmd.errfile = run_cmd.outfile
+        self.logger = logging.getLogger('unittest.RunCmdTests')
 
     def tearDown(self):
         plugins._reset_plugins()
@@ -25,12 +29,14 @@ class RunCmdTests(PavTestCase):
 
         run_cmd = commands.get_command('run')  # type: RunCommand
 
-        configs_by_sched = run_cmd._get_test_configs(pav_cfg=self.pav_cfg,
-                                                     host='this', test_files=[],
-                                                     tests=['hello_world'],
-                                                     modes=[], overrides={})
+        configs_by_sched = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
+                                                      host='this', test_files=[],
+                                                      tests=['hello_world'],
+                                                      modes=[], overrides={},
+                                                      logger=self.logger, outfile=sys.stdout
+                                                      )
 
-        tests = run_cmd._configs_to_tests(
+        tests = cmd_utils.configs_to_tests(
             pav_cfg=self.pav_cfg,
             configs_by_sched=configs_by_sched,
         )
@@ -47,13 +53,14 @@ class RunCmdTests(PavTestCase):
 
         tests_file = self.TEST_DATA_ROOT/'run_test_list'
 
-        configs_by_sched = run_cmd._get_test_configs(pav_cfg=self.pav_cfg,
-                                                     host='this',
-                                                     test_files=[tests_file],
-                                                     tests=[], modes=[],
-                                                     overrides={})
+        configs_by_sched = cmd_utils.get_test_configs(pav_cfg=self.pav_cfg,
+                                                      host='this',
+                                                      test_files=[tests_file],
+                                                      tests=[], modes=[],
+                                                      overrides={},
+                                                      logger=self.logger, outfile=sys.stdout)
 
-        tests = run_cmd._configs_to_tests(
+        tests = cmd_utils.configs_to_tests(
             pav_cfg=self.pav_cfg,
             configs_by_sched=configs_by_sched,
         )


### PR DESCRIPTION
Didn't change/add anything user-facing, just refactored.

Addresses the following comments from #107:
- [`get_test_configs` should return list of tests](https://github.com/hpc/pavilion2/pull/107#discussion_r492444462) 
- [`configs_to_tests` should take list of tests and return list of test objects](https://github.com/hpc/pavilion2/pull/107#discussion_r492444512)

Also moved some methods out of `RunCommand`, for easier merging with the new series file stuff. 