### PR TITLE
Lockfile Streamlining

### DIFF
--- a/lib/pavilion/builder.py
+++ b/lib/pavilion/builder.py
@@ -17,6 +17,7 @@ import urllib.parse
 from collections import defaultdict
 from pathlib import Path
 from typing import Union, List
+from concurrent.futures import ThreadPoolExecutor
 
 from pavilion import dir_db
 from pavilion import extract
@@ -488,7 +489,9 @@ class TestBuilder:
                 state=STATES.BUILD_WAIT,
                 note="Waiting on lock for build {}.".format(self.name))
             lock_path = self.path.with_suffix('.lock')
-            with lockfile.LockFile(lock_path, group=self._pav_cfg.shared_group):
+            with lockfile.LockFile(lock_path,
+                                   group=self._pav_cfg.shared_group)\
+                    as lock:
                 # Make sure the build wasn't created while we waited for
                 # the lock.
                 if not self.finished_path.exists():
@@ -517,7 +520,7 @@ class TestBuilder:
                     # non-catastrophic cases.
                     with PermissionsManager(self.path, self._group,
                                             self._umask):
-                        if not self._build(self.path, cancel_event):
+                        if not self._build(self.path, cancel_event, lock=lock):
 
                             try:
                                 self.path.rename(self.fail_path)
@@ -564,17 +567,26 @@ class TestBuilder:
 
         return True
 
-    def _build(self, build_dir, cancel_event):
+    def _build(self, build_dir, cancel_event, lock: lockfile.LockFile = None):
         """Perform the build. This assumes there actually is a build to perform.
         :param Path build_dir: The directory in which to perform the build.
         :param threading.Event cancel_event: Event to signal that the build
-        should stop.
+            should stop.
+        :param lock: The lockfile object. This will need to be refreshed to
+            keep it from expiring.
         :returns: True or False, depending on whether the build appears to have
             been successful.
         """
 
         try:
-            self._setup_build_dir(build_dir)
+            future = ThreadPoolExecutor().submit(
+                self._setup_build_dir,
+                build_dir)
+            while future.running():
+                time.sleep(lock.SLEEP_PERIOD)
+                lock.renew()
+            # Raise any errors raised by the thread.
+            future.result()
         except TestBuilderError as err:
             self.tracker.error(
                 note=("Error setting up build directory '{}': {}"
@@ -597,6 +609,7 @@ class TestBuilder:
                     try:
                         result = proc.wait(timeout=1)
                     except subprocess.TimeoutExpired:
+                        lock.renew()
                         if self._timeout_file.exists():
                             timeout_file = self._timeout_file
                         else:
@@ -1087,8 +1100,9 @@ def delete_unused(tests_dir: Path, builds_dir: Path, verbose: bool = False) \
 
     lock_path = builds_dir.with_suffix('.lock')
     msgs = []
-    with lockfile.LockFile(lock_path):
+    with lockfile.LockFile(lock_path) as lock:
         for path in dir_db.select(builds_dir, filter_builds, fn_base=16)[0]:
+            lock.renew()
             try:
                 shutil.rmtree(path.as_posix())
                 path.with_suffix(TestBuilder.FINISHED_SUFFIX).unlink()

--- a/lib/pavilion/dir_db.py
+++ b/lib/pavilion/dir_db.py
@@ -219,7 +219,7 @@ def delete(id_dir: Path, filter_func: Callable[[Path], bool] = default_filter,
     msgs = []
 
     lock_path = id_dir.with_suffix('.lock')
-    with lockfile.LockFile(lock_path):
+    with lockfile.LockFile(lock_path, timeout=1):
         for path in select(id_dir=id_dir, filter_func=filter_func,
                            transform=transform)[1]:
             try:

--- a/lib/pavilion/result/__init__.py
+++ b/lib/pavilion/result/__init__.py
@@ -118,11 +118,12 @@ def prune_result_log(log_path: Path, ids: List[str]) -> List[dict]:
     rewrite_log_path = log_path.with_suffix('.rewrite')
     lockfile_path = log_path.with_suffix(log_path.suffix + '.lock')
 
-    with _lockfile.LockFile(lockfile_path), \
+    with _lockfile.LockFile(lockfile_path) as lock, \
          log_path.open() as result_log, \
             rewrite_log_path.open('w') as rewrite_log:
 
         for line in result_log:
+            lock.renew()
             try:
                 result = json.loads(line)
             except json.JSONDecodeError:

--- a/lib/pavilion/test_run.py
+++ b/lib/pavilion/test_run.py
@@ -645,16 +645,11 @@ class TestRun(TestAttributes):
         """Load a saved test configuration."""
         config_path = test_path/'config'
 
-        # make lock
-        lock_path = test_path/'config.lockfile'
-        config_lock = lockfile.LockFile(lock_path)
-
         if not config_path.is_file():
             raise TestRunError("Could not find config file for test at {}."
                                .format(test_path))
 
         try:
-            config_lock.lock()
             with config_path.open('r') as config_file:
                 # Because only string keys are allowed in test configs,
                 # this is a reasonable way to load them.
@@ -665,8 +660,6 @@ class TestRun(TestAttributes):
         except (IOError, OSError) as err:
             raise TestRunError("Error reading config file '{}': {}"
                                .format(config_path, err))
-        finally:
-            config_lock.unlock()
 
     def build(self, cancel_event=None):
         """Build the test using its builder object and symlink copy it to

--- a/test/tests/lock_tests.py
+++ b/test/tests/lock_tests.py
@@ -38,7 +38,10 @@ class TestLocking(PavTestCase):
 
         # Making sure that we can automatically acquire and delete an
         # expired lockfile.
-        lockfile.LockFile._create_lockfile(self.lock_path, -100, '1234')
+        lockfile.LockFile._create_lockfile(
+            path=self.lock_path,
+            expires=-100,
+            lock_id='1234')
         with lockfile.LockFile(self.lock_path, timeout=1):
             pass
 


### PR DESCRIPTION
The cross-system lockfile tests ran fine.

aarch systems are really slow at getting update nfs metadata, as usual, so they're only able to acquire a lock after any contention has been resolved.