### PR TITLE
pav log series s<id>, hide _series from pav --help

### DIFF
--- a/lib/pavilion/plugins/commands/_series.py
+++ b/lib/pavilion/plugins/commands/_series.py
@@ -9,9 +9,8 @@ class AutoSeries(commands.Command):
 
     def __init__(self):
         super().__init__(
-            name='_series',
-            description='Runs an existing series object.',
-            short_help='Runs an existing series object.',
+            '_series',
+            'Runs an existing series object.',
         )
 
     def _setup_arguments(self, parser):

--- a/lib/pavilion/plugins/commands/log.py
+++ b/lib/pavilion/plugins/commands/log.py
@@ -5,6 +5,7 @@ import errno
 from pavilion import commands
 from pavilion import output
 from pavilion import test_run
+from pavilion import series, series_config
 
 
 class LogCommand(commands.Command):
@@ -52,14 +53,21 @@ class LogCommand(commands.Command):
             description="Displays the results log (results.log)"
         )
 
-        parser.add_argument('test', type=int,
-                            help="Test number argument.")
+        subparsers.add_parser(
+            'series',
+            help="Show a series's output (series.out).",
+            description="Displays the series output (series.log)."
+        )
+
+        parser.add_argument('ts_id', type=str,
+                            help="Test number or series id (e.g. s7) argument.")
 
     LOG_PATHS = {
         'build': 'build.log',
         'kickoff': 'kickoff.log',
         'results': 'results.log',
         'run': 'run.log',
+        'series': 'series.out'
     }
 
     def run(self, pav_cfg, args):
@@ -72,9 +80,17 @@ class LogCommand(commands.Command):
             cmd_name = args.log_cmd
 
         try:
-            test = test_run.TestRun.load(pav_cfg, args.test)
+            if cmd_name == 'series':
+                test = series.TestSeries.from_id(pav_cfg, args.ts_id)
+            else:
+                test = test_run.TestRun.load(pav_cfg, int(args.ts_id))
         except test_run.TestRunError as err:
             output.fprint("Error loading test: {}".format(err),
+                          color=output.RED,
+                          file=self.errfile)
+            return 1
+        except series_config.SeriesConfigError as err:
+            output.fprint("Error loading series: {}".format(err),
                           color=output.RED,
                           file=self.errfile)
             return 1

--- a/lib/pavilion/series_config/__init__.py
+++ b/lib/pavilion/series_config/__init__.py
@@ -80,7 +80,7 @@ def load_series_configs(pav_cfg, series_name: str, cl_modes: List[str],
                                                         series_name)
     if not series_file_path:
         raise SeriesConfigError('Cannot find series config: {}'.
-                                format(args.series_name))
+                                format(series_name))
 
     try:
         with series_file_path.open() as series_file:

--- a/lib/pavilion/series_config/__init__.py
+++ b/lib/pavilion/series_config/__init__.py
@@ -95,7 +95,7 @@ def load_series_configs(pav_cfg, series_name: str, cl_modes: List[str],
                 )
 
             # add modes and host from command line to config
-            series_cfg['modes'] = all_modes
+            series_cfg['modes'].extend(cl_modes)
             series_cfg['host'] = cl_host
     except AttributeError as err:
         raise SeriesConfigError("Cannot load series. {}".format(err.args[0]))

--- a/test/tests/log_cmd_tests.py
+++ b/test/tests/log_cmd_tests.py
@@ -37,7 +37,7 @@ class LogCmdTest(PavTestCase):
 
         # test `pav log run test`
         args = parser.parse_args(['run', str(test.id)])
-        self.assertEqual(args.test, test.id)
+        self.assertEqual(args.ts_id, str(test.id))
 
         out = io.StringIO()
         err = io.StringIO()

--- a/test/tests/series_tests.py
+++ b/test/tests/series_tests.py
@@ -60,8 +60,6 @@ class SeriesFileTests(PavTestCase):
 
         test_starts = []
         for test_id, test_obj in test_series_obj.tests.items():
-            from pavilion import output
-            output.dbg_print(test_obj.results, color=output.RED)
             test_starts.append(datetime.strptime(test_obj.results['started'],
                                                  '%Y-%m-%d %H:%M:%S.%f'))
 

--- a/test/tests/series_tests.py
+++ b/test/tests/series_tests.py
@@ -56,10 +56,12 @@ class SeriesFileTests(PavTestCase):
         test_series_obj.run_series()
 
         # make sure test actually ends
-        time.sleep(2)
+        time.sleep(3)
 
         test_starts = []
         for test_id, test_obj in test_series_obj.tests.items():
+            from pavilion import output
+            output.dbg_print(test_obj.results, color=output.RED)
             test_starts.append(datetime.strptime(test_obj.results['started'],
                                                  '%Y-%m-%d %H:%M:%S.%f'))
 


### PR DESCRIPTION
1. added `pav log series s<id>` 
2. hide `_series` from `pav --help`
3. added a second to the sleep function call in the `series_simultaneous` test 
4. BUG: fixed modes handling issue