### PR TITLE
fixed series outfile bug

### DIFF
--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -134,7 +134,8 @@ class RunCommand(commands.Command):
             fprint("You must specify at least one test.", file=self.errfile)
             return errno.EINVAL
 
-        series = TestSeries(pav_cfg, all_tests)
+        series = TestSeries(pav_cfg=pav_cfg, tests=all_tests,
+                            outfile=self.outfile, errfile=self.errfile)
         self.last_series = series
 
         res = cmd_utils.check_result_format(all_tests, self.errfile)


### PR DESCRIPTION
This shows the `4 tests started as test series s2.` line when I'm starting tests via `pav run`. 