### PR TITLE
fixed command-line overrides

### DIFF
--- a/lib/pavilion/plugins/commands/run.py
+++ b/lib/pavilion/plugins/commands/run.py
@@ -145,7 +145,8 @@ class RunCommand(commands.Command):
         series_obj = TestSeries(pav_cfg,
                                 series_config=series_cfg,
                                 outfile=self.outfile,
-                                errfile=self.errfile)
+                                errfile=self.errfile,
+                                overrides=args.overrides)
 
         series_obj.create_set_graph()
         only_set = series_obj.test_sets['only_set']

--- a/lib/pavilion/series.py
+++ b/lib/pavilion/series.py
@@ -85,6 +85,7 @@ class TestSet:
                 host=self.host,
                 tests=self._test_names,
                 modes=self.modes,
+                overrides=self.series_obj.overrides,
                 outfile=self.outfile,
                 conditions=new_conditions,
             )
@@ -266,7 +267,7 @@ class TestSeries:
     SERIES_COMPLETE_FN = 'SERIES_COMPLETE'
 
     def __init__(self, pav_cfg, tests=None, _id=None, series_config=None,
-                 dep_graph=None, outfile: TextIO = StringIO(),
+                 dep_graph=None, overrides=None, outfile: TextIO = StringIO(),
                  errfile: TextIO = StringIO()):
         """Initialize the series.
 
@@ -291,6 +292,7 @@ class TestSeries:
             self.dep_graph = dep_graph
         self.test_sets = {}  # type: Dict[str, TestSet]
         self.test_objs = {}
+        self.overrides = overrides
 
         if tests:
             self.tests = {test.id: test for test in tests}


### PR DESCRIPTION
Fixed a bug introduced in an earlier commit that made command-line overrides not apply anymore. Fixes #390 