### PR TITLE
Pav status/results fix.

### DIFF
--- a/bin/pav.py
+++ b/bin/pav.py
@@ -110,11 +110,14 @@ def main():
         sys.exit(0)
 
     pav_cfg.pav_vars = pavilion_variables.PavVars()
-
-    if args.tests:
-        if args.sys_name is not None: args.sys_name = ''
-        if args.user is not None: args.user = ''
-        if args.newer_than is not None: args.newer_than = None
+    
+    try:
+        if args.tests:
+            if args.sys_name is not None: args.sys_name = ''
+            if args.user is not None: args.user = ''
+            if args.newer_than is not None: args.newer_than = None
+    except AttributeError:
+        pass
 
     if not args.profile:
         run_cmd(pav_cfg, args)

--- a/bin/pav.py
+++ b/bin/pav.py
@@ -111,6 +111,11 @@ def main():
 
     pav_cfg.pav_vars = pavilion_variables.PavVars()
 
+    if args.tests:
+        if args.sys_name is not None: args.sys_name = ''
+        if args.user is not None: args.user = ''
+        if args.newer_than is not None: args.newer_than = None
+
     if not args.profile:
         run_cmd(pav_cfg, args)
 


### PR DESCRIPTION
Fixed status/results issue, where, given a series or test id run by another user or >1 day ago or on a different system, pav status/result returns nothing.  This is the result of default values for user, newer-than, and sys_name constraining the output inappropriately.