### PR TITLE
Added mutliprocessing to status query.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ PAV/scripts/site
 *.swp
 *.swo
 pav.pstats
+.local/
+__pycache__/

--- a/lib/pavilion/status_utils.py
+++ b/lib/pavilion/status_utils.py
@@ -2,8 +2,12 @@
 and series."""
 
 import os
+import sys
 import time
+import psutil
+import multiprocessing as mp
 from typing import TextIO, List
+from functools import partial
 
 from pavilion import commands
 from pavilion import output
@@ -103,6 +107,29 @@ def get_tests(pav_cfg, tests: List['str'], errfile: TextIO) -> List[int]:
     return list(map(int, test_list))
 
 
+def get_status(test_id, pav_conf):
+    """Return the status of a single test_id.
+    Allows the statuses to be queried in parallel with map.
+    :param test_id: The test id being queried.
+    :param pav_conf: The Pavilion config.
+    """
+
+    try:
+        test = TestRun.load(pav_conf, test_id)
+        test_status = status_from_test_obj(pav_conf, test)
+
+    except (TestRunError, TestRunNotFoundError) as err:
+        test_status = {
+            'test_id': test_id,
+            'name':    "",
+            'state':   STATES.UNKNOWN,
+            'time':    None,
+            'note':    "Test not found: {}".format(err)
+        }
+
+    return test_status
+
+
 def get_statuses(pav_cfg, test_ids, errfile=None):
     """Return the statuses for all given test id's.
     :param pav_cfg: The Pavilion config.
@@ -110,23 +137,18 @@ def get_statuses(pav_cfg, test_ids, errfile=None):
     :param errfile: Where to write standard error to.
     """
 
-    test_statuses = []
-
     test_ids = get_tests(pav_cfg, test_ids, errfile=errfile)
 
-    for test_id in test_ids:
-        try:
-            test = TestRun.load(pav_cfg, test_id)
-            test_statuses.append(status_from_test_obj(pav_cfg, test))
+    get_this_status = partial(get_status, pav_conf=pav_cfg)
 
-        except (TestRunError, TestRunNotFoundError) as err:
-            test_statuses.append({
-                'test_id': test_id,
-                'name':    "",
-                'state':   STATES.UNKNOWN,
-                'time':    None,
-                'note':    "Test not found: {}".format(err)
-            })
+    # The TestRun object cannot be pickled in python < 3.7 because 
+    # it contains threading which causes parallel execution to fail.
+    if sys.version_info.minor > 6:
+        ncpu = min(psutil.cpu_count(logical=False), len(test_ids))
+        p = mp.Pool(processes=ncpu)
+        test_statuses = p.map(get_this_status, test_ids)
+    else:
+        test_statuses = map(get_this_status, test_ids)
 
     return test_statuses
 


### PR DESCRIPTION
In status_utils.py encapsulate the main loop in a separate function, get_status, to make it easier to use with map.  Use functools partial to reduce get_status to a single input to make map easier (could use starmap, but that seems more complicated). TestRun can't be picked in python < 3.7 because of some threading capabilities in it, so don't run in parallel unless python is new enough to work. Use psutils to get cpu_count to avoid using virtual cores and oversaturating the (front-end) node.

Improve .gitignore to allow users to store temporary and info files locally in .local, and avoid pushing compiled cache files.