### PR TITLE
Parallelize test filter selection.

### DIFF
--- a/lib/pavilion/cmd_utils.py
+++ b/lib/pavilion/cmd_utils.py
@@ -63,10 +63,7 @@ def arg_filtered_tests(pav_cfg, args: argparse.Namespace,
         show_skipped=args.show_skipped,
     )
 
-    order_func, order_asc = filters.get_sort_opts(
-        sort_name=args.sort_by,
-        choices=filters.TEST_SORT_FUNCS,
-    )
+    order_func, order_asc = filters.get_sort_opts(args.sort_by, "TEST")
 
     if args.tests:
         test_paths = test_list_to_paths(pav_cfg, args.tests)

--- a/lib/pavilion/config.py
+++ b/lib/pavilion/config.py
@@ -46,6 +46,10 @@ PAV_ROOT = Path(__file__).resolve().parents[2]
 # Use this config file, if it exists.
 PAV_CONFIG_FILE = os.environ.get('PAV_CONFIG_FILE', None)
 
+NCPU = os.cpu_count()
+if NCPU > 40:
+    NCPU = NCPU//2
+NCPU = NCPU//2
 
 class ExPathElem(yc.PathElem):
     """Expand environment variables in the path."""

--- a/lib/pavilion/dir_db.py
+++ b/lib/pavilion/dir_db.py
@@ -8,13 +8,13 @@ import os
 import shutil
 import tempfile
 import time
-import psutil
 import multiprocessing as mp
 from functools import partial
 from pathlib import Path
 from typing import Callable, List, Iterable, Any, Dict, NewType, \
     Union, NamedTuple, IO
 
+from pavilion import config
 from pavilion import lockfile
 from pavilion import output
 from pavilion import permissions
@@ -404,13 +404,13 @@ def select_from(paths: Iterable[Path],
               of untransformed paths.
     """
 
-    paths=list(paths)
-    ncpu = min(psutil.cpu_count(logical=False), len(paths))
-    p = mp.Pool(processes=ncpu)
+    paths = list(paths)
+    ncpu = min(config.NCPU, len(paths))
+    mp_pool = mp.Pool(processes=ncpu)
 
     selector = partial(select_one, ff=filter_func, trans=transform, ofunc=order_func, fnb=fn_base)
 
-    selections = p.map(selector, paths)
+    selections = mp_pool.map(selector, paths)
     selected = [(item,path) for item, path in zip(selections,paths) if item is not None]
 
     if order_func is not None:

--- a/lib/pavilion/dir_db.py
+++ b/lib/pavilion/dir_db.py
@@ -62,7 +62,7 @@ def create_id_dir(id_dir: Path, group: str, umask: int) -> (int, Path):
     :returns: The id and path to the created directory.
     :raises OSError: on directory creation failure.
     :raises TimeoutError: If we couldn't get the lock in time.
-"""
+    """
 
     lockfile_path = id_dir/'.lockfile'
     with lockfile.LockFile(lockfile_path, timeout=1):
@@ -120,9 +120,11 @@ def default_filter(_: Path) -> bool:
 
 Index = NewType("Index", Dict[int, Dict['str', Any]])
 
+
 def identity(value):
     """Because lambdas can't be pickled."""
     return value
+
 
 def index(id_dir: Path, idx_name: str,
           transform: Callable[[Path], Dict[str, Any]],
@@ -260,8 +262,8 @@ SelectItems = NamedTuple("SelectItems", [('data', List[Dict[str, Any]]),
                                          ('paths', List[Path])])
 
 def select_one(path, ffunc, trans, ofunc, fnb):
-    """
-    Allows the objects to be filtered and transformed in parallel with map.
+    """Allows the objects to be filtered and transformed in parallel with map.
+
     :param path: Path to filter and transform (input to reduced function)
     :param ffunc: (filter function) Function that takes a directory, and returns
         whether to include that directory. True -> include, False -> exclude

--- a/lib/pavilion/filters.py
+++ b/lib/pavilion/filters.py
@@ -243,6 +243,7 @@ def filter_test_run(
     """Determine whether the test run at the given path should be
     included in the set. This function with test_attrs as the sole input is
     returned by make_test_run_filter.
+    
     :param test_attrs: Dict of attributes filtered to determine whether to
     keep or discard test.
     Arguments set by make_test_run_filter.

--- a/lib/pavilion/filters.py
+++ b/lib/pavilion/filters.py
@@ -243,10 +243,9 @@ def filter_test_run(
     """Determine whether the test run at the given path should be
     included in the set. This function with test_attrs as the sole input is
     returned by make_test_run_filter.
-    
+
     :param test_attrs: Dict of attributes filtered to determine whether to
-    keep or discard test.
-    Arguments set by make_test_run_filter.
+        keep or discard test.
     :param complete: Only accept complete tests
     :param failed: Only accept failed tests
     :param incomplete: Only accept incomplete tests

--- a/lib/pavilion/filters.py
+++ b/lib/pavilion/filters.py
@@ -6,6 +6,8 @@ import datetime as dt
 import time
 import fnmatch
 from pathlib import Path
+from functools import partial
+
 from typing import Dict, Any, Callable, List
 
 from pavilion import system_variables
@@ -28,18 +30,26 @@ TEST_FILTER_DEFAULTS = {
     'user': utils.get_login(),
     'limit': None,
     'disable_filter': False,
-
 }
 
-TEST_SORT_FUNCS = {
-    'created': lambda test: test['created'],
-    'finished': lambda test: test['finished'],
-    'name': lambda test: test['name'],
-    'started': lambda test: test['started'],
-    'user': lambda test: test['user'],
-    'id': lambda test: test['id'],
+SORT_KEYS = {
+    "TEST": ["created", "finished", "name", "started", "user", "id"],
+    "SERIES": ["created", "id"]
 }
 
+def sort_func(test, choice, sort_type):
+    """Use partial to reduce inputs and use as key in sort function.
+    :param test: Dict within list to sort on.
+    :param choice: Key in dict to sort by.
+    :param sort_type: Type of list of dicts to sort by, check for key.
+    """
+
+    if sort_type not in SORT_KEYS.keys():
+        return None
+    elif choice not in SORT_KEYS[sort_type]:
+        return None
+    else:
+        return test[choice]
 
 def add_common_filter_args(target: str,
                            arg_parser: argparse.ArgumentParser,
@@ -142,10 +152,10 @@ def add_test_filter_args(arg_parser: argparse.ArgumentParser,
                 )
 
     if sort_functions is None:
-        sort_functions = TEST_SORT_FUNCS.copy()
+        sort_functions = SORT_KEYS['TEST']
 
-    sort_options = (list(sort_functions.keys())
-                    + ['-' + key for key in sort_functions.keys()])
+    sort_options = (sort_functions
+                    + ['-' + key for key in sort_functions])
 
     add_common_filter_args("test runs", arg_parser, defaults, sort_options)
 
@@ -190,12 +200,6 @@ add_test_filter_args.__doc__.format(
                for key, val in TEST_FILTER_DEFAULTS.items()]))
 
 
-SERIES_SORT_FUNCS = {
-    'created': lambda p: p['created'],
-    'id': lambda p: p['id'],
-}
-
-
 def add_series_filter_args(arg_parser: argparse.ArgumentParser,
                            default_overrides: Dict[str, Any] = None,
                            sort_functions: Dict[str, Callable] = None) -> None:
@@ -224,12 +228,54 @@ def add_series_filter_args(arg_parser: argparse.ArgumentParser,
                 )
 
     if sort_functions is None:
-        sort_functions = SERIES_SORT_FUNCS.copy()
+        sort_functions = SORT_KEYS["SERIES"]
 
-    sort_options = (list(sort_functions.keys())
-                    + ['-' + key for key in sort_functions.keys()])
+    sort_options = (sort_functions
+                    + ['-' + key for key in sort_functions])
 
     add_common_filter_args("series", arg_parser, defaults, sort_options)
+
+#  select once so we only make one filter.
+def filter_test_run(test_attrs, cmp, fail, incmp, nm, nt, ot, pss, rslte, ss, sn, usr):
+    """Determine whether the test run at the given path should be
+    included in the set."""
+
+    if ss == 'no' and test_attrs.get('skipped'):
+        return False
+    elif ss == 'only' and not test_attrs.get('skipped'):
+        return False
+
+    if cmp and not test_attrs.get('complete'):
+        return False
+
+    if incmp and test_attrs.get('complete'):
+        return False
+
+    if usr and test_attrs.get('user') != usr:
+        return False
+
+    if sn and sn != test_attrs.get('sys_name'):
+        return False
+
+    if pss and test_attrs.get('result') != TestRun.PASS:
+        return False
+
+    if fail and test_attrs.get('result') != TestRun.FAIL:
+        return False
+
+    if rslte and test_attrs.get('result') != TestRun.ERROR:
+        return False
+
+    if ot is not None and test_attrs.get('created') > ot:
+        return False
+
+    if nt is not None and test_attrs.get('created') < nt:
+        return False
+
+    if nm and not fnmatch.fnmatch(test_attrs.get('name'), nm):
+        return False
+
+    return True
 
 
 def make_test_run_filter(
@@ -260,73 +306,33 @@ def make_test_run_filter(
         sys_vars = system_variables.get_vars(defer=True)
         sys_name = sys_vars['sys_name']
 
-    #  select once so we only make one filter.
-    def filter_test_run(test_attrs: dict) -> bool:
-        """Determine whether the test run at the given path should be
-        included in the set."""
+    # cmp, fail, incmp, nm, nt, ot, pss, rslte, ss, sn, usr
 
-        if show_skipped == 'no' and test_attrs.get('skipped'):
-            return False
-        elif show_skipped == 'only' and not test_attrs.get('skipped'):
-            return False
+    ftr = partial(filter_test_run, cmp=complete, fail=failed, incmp=incomplete,
+                  nm=name, nt=newer_than, ot=older_than, pss=passed, rslte=result_error,
+                  ss=show_skipped, sn=sys_name, usr=user)
 
-        if complete and not test_attrs.get('complete'):
-            return False
-
-        if incomplete and test_attrs.get('complete'):
-            return False
-
-        if user and test_attrs.get('user') != user:
-            return False
-
-        if sys_name and sys_name != test_attrs.get('sys_name'):
-            return False
-
-        if passed and test_attrs.get('result') != TestRun.PASS:
-            return False
-
-        if failed and test_attrs.get('result') != TestRun.FAIL:
-            return False
-
-        if result_error and test_attrs.get('result') != TestRun.ERROR:
-            return False
-
-        if older_than is not None and test_attrs.get('created') > older_than:
-            return False
-
-        if newer_than is not None and test_attrs.get('created') < newer_than:
-            return False
-
-        if name and not fnmatch.fnmatch(test_attrs.get('name'), name):
-            return False
-
-        return True
-
-    return filter_test_run
+    return ftr
 
 
 def get_sort_opts(
         sort_name: str,
-        choices: Dict[str, Callable[[Any], Any]]) \
-        -> (Callable[[Path], Any], bool):
+        stype: str) -> (Callable[[Path], Any], bool):
     """Return a sort function and the sort order.
 
     :param sort_name: The name of the sort, possibly prepended with '-'.
-    :param choices: A dictionary of sort order names and
-        key functions (ala list.sort). Defaults to TEST_SORT_FUNCS
-    :returns: A tuple of the sort function and ascending boolean
+    :param stype: TEST or SERIES to select the list of options available
+    for sort_name.
     """
 
     sort_ascending = True
     if sort_name.startswith('-'):
         sort_ascending = False
         sort_name = sort_name[1:]
+    
+    sortf = partial(sort_func, choice=sort_name, sort_type=stype)
 
-    if sort_name not in choices:
-        raise ValueError("Invalid sort name '{}'. Must be one of {}."
-                         .format(sort_name, tuple(choices.keys())))
-
-    return choices[sort_name], sort_ascending
+    return sortf, sort_ascending
 
 
 SERIES_FILTER_DEFAULTS = {

--- a/lib/pavilion/filters.py
+++ b/lib/pavilion/filters.py
@@ -338,9 +338,9 @@ def get_sort_opts(
         stype: str) -> (Callable[[Path], Any], bool):
     """Return a sort function and sort order.
 
-    :param sort_name: The name of the sort, possibly prepended with '-'.
+    :param sort_name: The name of the sort, possibly prepended with -.
     :param stype: TEST or SERIES to select the list of options available
-    for sort_name.
+        for sort_name.
     """
 
     sort_ascending = True

--- a/lib/pavilion/plugins/commands/list_cmd.py
+++ b/lib/pavilion/plugins/commands/list_cmd.py
@@ -236,8 +236,7 @@ class ListCommand(commands.Command):
             user=args.user,
         )
 
-        order_func, ascending = filters.get_sort_opts(
-            args.sort_by, filters.TEST_SORT_FUNCS)
+        order_func, ascending = filters.get_sort_opts(ßargs.sort_by, "TEST")
 
         if args.series:
             picked_runs = []
@@ -313,9 +312,7 @@ class ListCommand(commands.Command):
             older_than=args.older_than,
             sys_name=args.sys_name)
 
-        series_order, ascending = filters.get_sort_opts(
-            sort_name=args.sort_by,
-            choices=filters.SERIES_SORT_FUNCS)
+        series_order, ascending = filters.get_sort_opts(args.sort_by,"SERIES")
 
         series = dir_db.select(
             id_dir=pav_cfg.working_dir/'series',

--- a/test/tests/filter_tests.py
+++ b/test/tests/filter_tests.py
@@ -95,7 +95,7 @@ class FiltersTest(PavTestCase):
 
         common_parser = NoExitParser()
         series_parser = NoExitParser()
-        sort_opts = list(filters.SERIES_SORT_FUNCS.keys())
+        sort_opts = list(filters.SORT_KEYS["SERIES"])
 
         filters.add_common_filter_args("", common_parser,
                                        filters.SERIES_FILTER_DEFAULTS,
@@ -261,7 +261,7 @@ class FiltersTest(PavTestCase):
         paths = [test.path for test in tests]
 
         # Check sorting in ascending direction
-        sort, ascending = filters.get_sort_opts('id', filters.TEST_SORT_FUNCS)
+        sort, ascending = filters.get_sort_opts('id', "TEST")
         self.assertTrue(ascending)
         sorted_tests = dir_db.select_from(
             paths=paths,
@@ -270,7 +270,7 @@ class FiltersTest(PavTestCase):
         self.assertEqual([t['id'] for t in sorted_tests], ids)
 
         # And descending.
-        sort, ascending = filters.get_sort_opts('-id', filters.TEST_SORT_FUNCS)
+        sort, ascending = filters.get_sort_opts('-id', "TEST")
         self.assertFalse(ascending)
         sorted_tests = dir_db.select_from(
             paths=paths,


### PR DESCRIPTION
Encapsulate the main loop over paths in dir_db.select_from to transform and filter the paths in parallel.

Two consequences of this change motivated the other changes.
First, functions declared within other functions can't be pickled.  So move filters.filter_test_run out of the make_test_run_filter function and return it with the same arguments using functools.partial and the make_test_run_filter arguments.
Second, lambdas can't be pickled. So let order_func be a function defined in the top level of the filters module, sort_func, rather than a lambda stored as a value in a dictionary. This eliminates the SERIES_SORT_FUNC and TEST_SORT_FUNC dictionaries and replaces them with a dictionary with keys TEST and SERIES and values that are valid sort keys for these types of dictionaries. The order_func acts the same as previously, but any function that took the SORT_FUNC dicts as inputs now take a string (TEST or SERIES) instead.