### PR TITLE
Fixes the key flag for the 'pav results' command which currently does not work.  C…

### DIFF
--- a/lib/pavilion/output.py
+++ b/lib/pavilion/output.py
@@ -755,7 +755,7 @@ def dt_auto_widths(rows, table_width, min_widths, max_widths):
     so on. Remaining extra space is distributed amongst the final tied
     columns. To limit how long this takes, this makes a best guess using
     the first 20 rows."""
-	
+
     mxwidth = sum(max_widths.values())
     if mxwidth <= table_width:
         return max_widths

--- a/lib/pavilion/output.py
+++ b/lib/pavilion/output.py
@@ -755,6 +755,10 @@ def dt_auto_widths(rows, table_width, min_widths, max_widths):
     so on. Remaining extra space is distributed amongst the final tied
     columns. To limit how long this takes, this makes a best guess using
     the first 20 rows."""
+	
+    mxwidth = sum(max_widths.values())
+    if mxwidth <= table_width:
+        return max_widths
 
     fields = list(min_widths.keys())
 

--- a/lib/pavilion/plugins/commands/result.py
+++ b/lib/pavilion/plugins/commands/result.py
@@ -40,9 +40,8 @@ class ResultsCommand(commands.Command):
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
-            "-k", "--key",
-            action='append', nargs="*", default=[],
-            help="Additional result keys to display."
+            "-k", "--key", type=str, default='',
+            help="Comma separated list of additional result keys to display."
         )
         group.add_argument(
             "-f", "--full", action="store_true", default=False,
@@ -117,7 +116,7 @@ class ResultsCommand(commands.Command):
                 pass
 
         else:
-            fields = result_utils.BASE_FIELDS + args.key
+            fields = result_utils.BASE_FIELDS + args.key.replace(',',' ').split()
 
             output.draw_table(
                 outfile=self.outfile,


### PR DESCRIPTION
…urrently, if you put the series or test number after -l, 'pav results -k duration s29',  will simply call results with no series or tests and two keys duration and s29.  Furthermore if -k is called after the tests/series, the append action will place each key entry in its own list within a list, which causes an error in output.  This fixes that by taking the list of keys as a comma delimited string (which can also be a space delimited string enclosed by quotation marks).  It splits them and attaches them to the BASE_FIELDS.  Also included the skip dt_auto_widths condition because its very important.