### PR TITLE
Remove -w flag from subprocess calls. Fix mpirun command.

### DIFF
--- a/lib/pavilion/schedulers/plugins/slurm.py
+++ b/lib/pavilion/schedulers/plugins/slurm.py
@@ -105,7 +105,7 @@ class SlurmVars(SchedulerVariables):
 
             cmd.extend(slurm_conf['srun_extra'])
         else:
-            cmd = ['mpirun', 
+            cmd = ['mpirun',
                    '-np {}'.format(tasks),
                    '--map-by ppr:{}:node'.format(tpn)]
 


### PR DESCRIPTION
Pavilion itself is getting unavailable nodes in it's node list.  I could have fixed that but it would have required more digging and I think this solution is more parsimonious.  Setting the number of nodes and a list of particular nodes in sbatch/srun/mpirun makes the allocation overdetermined and brittle.  So I commented the -w lines out, you can remove them fully if you agree with my solution.  Also the mpirun command had no -np argument which is necessary.