### PR TITLE
Fixes --sort-by argument.

### DIFF
--- a/lib/pavilion/status_utils.py
+++ b/lib/pavilion/status_utils.py
@@ -133,8 +133,6 @@ def print_status(statuses, outfile, note=False, series=False, json=False):
 :rtype: int
 """
 
-    statuses.sort(key=lambda v: v.get('test_id'))
-
     if json:
         json_data = {'statuses': statuses}
         output.json_dump(json_data, outfile)

--- a/lib/pavilion/test_run/utils.py
+++ b/lib/pavilion/test_run/utils.py
@@ -50,8 +50,6 @@ def load_tests(pav_cfg, id_pairs: List[ID_Pair], errfile: TextIO) -> List['TestR
     :raises TestRunError: When loading a test fails
     """
 
-    id_pairs = set(id_pairs)
-
     tests = []
 
     # Only load tests that haven't already been loaded.
@@ -59,14 +57,15 @@ def load_tests(pav_cfg, id_pairs: List[ID_Pair], errfile: TextIO) -> List['TestR
     for pair in id_pairs:
         if pair in LOADED_TESTS:
             tests.append(LOADED_TESTS[pair])
-        else:
+        elif pair not in not_loaded:
             not_loaded.append(pair)
-    id_pairs = not_loaded
+
+    id_filtered_pairs = not_loaded
 
     with ThreadPoolExecutor(max_workers=pav_cfg['max_threads']) as pool:
         results = []
-        for id_pair in id_pairs:
-            results.append(pool.submit(_load_test, pav_cfg, id_pair))
+        for pair in id_filtered_pairs:
+            results.append(pool.submit(_load_test, pav_cfg, pair))
 
         for result in results:
             try:


### PR DESCRIPTION
Before this PR, calling `pav result` will result in a random ordering of output rows.  Calling `pav status` will result in output rows sorted by id regardless of what argument is given to `--sort-by`.

This is because after the tests have been filtered, these commands call `cmd_utils.get_tests_by_paths`, which calls `load_tests` from `test_run/utils.py`, which immediately calls set on the list of tests to remove duplicates but also randomizes their order undoing the sort filter.  This would make the output random for both commands, but the status command calls status_utils in print_status which immediately sorts the tests by their id.  Using another method of removing duplicates (already half implemented by the load_tests function), and removing the sort in print_status resolves the issue.

-------

A final note on the topic of the `--sort-by` flag: using `-` at the start of the sort key to denote descending order is a bad idea.  Argparse uses `-` to recognize flags so passing `--sort-by -id` throws an error:
```
pav results: error: argument --sort-by: expected one argument
```

The key must be passed to the flag with `=` which is not denoted in the help string.  But this is confusing as the = is only needed for this one flag and only when passing a particular set of keys.  I would suggest just changing the logic to use `+` (or `<` or maybe `~`?) to denote descending order.