### PR TITLE
Replac --json with --outfile flag for query commands (result/status).  

### DIFF
--- a/lib/pavilion/commands/status.py
+++ b/lib/pavilion/commands/status.py
@@ -2,6 +2,7 @@
 other commands to print statuses."""
 
 import errno
+import sys
 
 from pavilion import cmd_utils
 from pavilion import filters
@@ -21,9 +22,8 @@ class StatusCommand(Command):
     def _setup_arguments(self, parser):
 
         parser.add_argument(
-            '-j', '--json', action='store_true', default=False,
-            help='Give output as json, rather than as standard human readable.'
-        )
+            '--outfile', '-o', action='store', default=self.outfile,
+            help='Send output to file, type dependent on extension (json).')
         parser.add_argument(
             '--series', action='store_true', default=False,
             help='Show the series the test belongs to.')
@@ -68,7 +68,7 @@ class StatusCommand(Command):
                               file=self.errfile,
                               color=output.RED)
                 return 1
-            return status_utils.print_status_history(tests[-1], self.outfile, args.json)
+            return status_utils.print_status_history(tests[-1], args.outfile)
 
         tests = cmd_utils.get_tests_by_paths(pav_cfg, test_paths, self.errfile)
 
@@ -76,8 +76,8 @@ class StatusCommand(Command):
         if args.summary:
             return self.print_summary(statuses)
         else:
-            return status_utils.print_status(statuses, self.outfile, json=args.json,
-                                             series=args.series, note=args.note)
+            return status_utils.print_status(statuses, args.outfile, series=args.series,
+                                             note=args.note)
 
     def print_summary(self, statuses):
         """Print_summary takes in a list of test statuses.

--- a/lib/pavilion/status_utils.py
+++ b/lib/pavilion/status_utils.py
@@ -118,7 +118,7 @@ def get_statuses(pav_cfg, tests: List[TestRun]):
         return list(pool.map(get_this_status, tests))
 
 
-def print_status(statuses: List[dict], outfile, note=False, series=False, json=False):
+def print_status(statuses: List[dict], outfile, note=False, series=False):
     """Prints the statuses provided in the statuses parameter.
 
 :param statuses: list of dictionary objects containing the test_id,
@@ -133,7 +133,7 @@ def print_status(statuses: List[dict], outfile, note=False, series=False, json=F
 :rtype: int
 """
 
-    if json:
+    if outfile.endswith('json'):
         json_data = {'statuses': statuses}
         output.json_dump(json_data, outfile)
     else:
@@ -195,7 +195,7 @@ def status_history_from_test_obj(test: TestRun) -> List[dict]:
     return status_history
 
 
-def print_status_history(test: TestRun, outfile: TextIO, json: bool = False):
+def print_status_history(test: TestRun, outfile: TextIO):
     """Print the status history for a given test object.
 
     :param test: Single test object.
@@ -210,7 +210,7 @@ def print_status_history(test: TestRun, outfile: TextIO, json: bool = False):
     for status in status_history:
         if status['note'] != "Test not found.":
             ret_val = 0
-    if json:
+    if outfile.endswith('json'):
         json_data = {'status_history': status_history}
         output.json_dump(json_data, outfile)
     else:

--- a/test/tests/status_cmd_tests.py
+++ b/test/tests/status_cmd_tests.py
@@ -28,15 +28,13 @@ class StatusCmdTests(PavTestCase):
 
         self.assertEqual(args.tests[0], 'test1')
         self.assertEqual(args.tests[1], 'test2')
-        self.assertEqual(args.json, False)
 
         parser = argparse.ArgumentParser()
         status_cmd._setup_arguments(parser)
-        args = parser.parse_args(['-j', 'test0', 'test9'])
+        args = parser.parse_args(['test0', 'test9'])
 
         self.assertEqual(args.tests[0], 'test0')
         self.assertEqual(args.tests[1], 'test9')
-        self.assertEqual(args.json, True)
 
     def test_status_command(self):
         """Test status command by generating a suite of tests."""


### PR DESCRIPTION
It's more useful to send json output to a json file. and more useful in general to have an outfile option so that any type of output can be saved to a file.  

This commit replaces the json flag with an outfile flag.  If the user specifies a file that doesn't have a '.json' extension, pavilion will print the usual output to that file instead of stdout.  If it does have a 'json' extension, it'll dump the relevant json  data structure to that file.  This way a single flag handles both use cases, the desired option to output the query results to a file, and the current option to format that output as a pavilion table or a json object. 