### PR TITLE
Fix profile count flag

### DIFF
--- a/bin/pav.py
+++ b/bin/pav.py
@@ -159,6 +159,6 @@ if __name__ == '__main__':
         cProfile.runctx('main()', globals(), locals(), stats_path)
         stats = pstats.Stats(stats_path)
         print("Profile Table")
-        stats.strip_dirs().sort_stats(p_sort).print_stats(p_count)
+        stats.strip_dirs().sort_stats(p_sort).print_stats(int(p_count))
     else:
         main()


### PR DESCRIPTION
The print_stats method for cProfile takes an int so cast the argument variable p_count to int when it's passed to the method.