### PR TITLE
Added a name filter argument for `pav show tests`

### DIFF
--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -35,14 +35,17 @@ class ShowTests(unittest.PavTestCase):
             ('show', 'suites', '--err'),
             ('show', 'suites', '--supersedes'),
             ('show', 'suites', '--verbose'),
+            ('show', 'suites', '--path'),
             ('show', 'system_variables'),
             ('show', 'system_variables', '--verbose'),
             ('show', 'test_config'),
             ('show', 'tests'),
+            ('show', 'tests', 'name_filter'),
             ('show', 'tests', '--err'),
             ('show', 'tests', '--doc', 'hello_world.narf'),
             ('show', 'tests', '--hidden'),
             ('show', 'tests', '--verbose'),
+            ('show', 'tests', '--path'),
         ]
 
         parser = arguments.get_parser()


### PR DESCRIPTION
- Added a name filter argument to filter show tests use `pav show tests <filter>`
- Added path for the test & suite files. Use `pav show tests/suites -p/--path` for path.