### PR TITLE
Add support for nodenames foo-[10-20]-[01-02].

### DIFF
--- a/lib/pavilion/schedulers/plugins/slurm.py
+++ b/lib/pavilion/schedulers/plugins/slurm.py
@@ -195,9 +195,9 @@ class Slurm(SchedulerPluginAdvanced):
 
     NODE_SEQ_REGEX_STR = (
         # The characters in a valid hostname.
-        r'[a-zA-Z][a-zA-Z_-]*\d*'
+        r'[a-zA-Z-][a-zA-Z0-9_-]*\d*'
         # A numeric range of nodes in square brackets.
-        r'(?:\[(?:\d+|\d+-\d+)(?:,\d+|,\d+-\d+)*\])?'
+        r'\-?(?:\[(?:\d+|\d+-\d+)(?:,\d+|,\d+-\d+)*\])?'
     )
     NODE_LIST_RE = re.compile(
         # Match a comma separated list of these things.

--- a/lib/pavilion/schedulers/plugins/slurm.py
+++ b/lib/pavilion/schedulers/plugins/slurm.py
@@ -207,7 +207,7 @@ class Slurm(SchedulerPluginAdvanced):
     NODE_BRACKET_FORMAT_RE = re.compile(
         # Match hostname followed by square brackets,
         # group whats in the brackets.
-        r'([a-zA-Z][a-zA-Z_-]*\d*)\[(.*)]'
+        r'([a-zA-Z][a-zA-Z0-9_-]*\d*)\[(.*)]'
     )
 
     def __init__(self):
@@ -329,7 +329,7 @@ class Slurm(SchedulerPluginAdvanced):
                         "Invalid Node List: '{}'. Syntax error in item '{}'. "
                         "Node lists components be a hostname or hostname "
                         "prefix followed by a range of node numbers. "
-                        "Ex: foo003,foo0[10-20],foo[103-104], foo[10,12-14]"
+                        "Ex: foo003,foo0[10-20],foo[103-104],foo[10,12-14],foo-m11-16"
                         .format(node_list, part)
                     )
 

--- a/test/tests/slurm_tests.py
+++ b/test/tests/slurm_tests.py
@@ -96,6 +96,8 @@ class SlurmTests(PavTestCase):
             (None, []),
             ('', []),
             ('ab03', ['ab03']),
+            ('cpn-m11-16', ['cpn-m11-16']),
+            ('cpn-m11-[16,18]', ['cpn-m11-16', 'cpn-m11-18']),
             ('ab-bc[3-004]', ['ab-bc3', 'ab-bc4']),
             ('ab_bc[03-10]',
              ['ab_bc{:02d}'.format(d) for d in range(3, 11)]),


### PR DESCRIPTION
Our node names look this this `cpn-m11-16`. When running pav we get the following error:

```
Unknown error running command _run: Invalid Node List: 'cpn-m11-16'. Syntax
error in item 'cpn-m11-16'. Node lists components be a hostname or hostname
prefix followed by a range of node numbers. Ex: foo003,foo0[10-20],foo[103-104],
foo[10,12-14].
```

This PR adjusts the node regex to support this naming convention.