### PR TITLE
Add sqrt function.

### DIFF
--- a/lib/pavilion/expression_functions/core.py
+++ b/lib/pavilion/expression_functions/core.py
@@ -93,6 +93,23 @@ class CeilPlugin(CoreFunctionPlugin):
         return math.ceil(val)
 
 
+class SqrtPlugin(CoreFunctionPlugin):
+    """Get the square root of the given number."""
+
+    def __init__(self):
+        """Setup plugin."""
+
+        super().__init__(
+            name="sqrt",
+            arg_specs=(float,))
+
+    @staticmethod
+    def sqrt(val):
+        """Get the square root of the given number."""
+
+        return math.sqrt(val)
+
+
 class SumPlugin(CoreFunctionPlugin):
     """Get the floating point sum of the given numbers."""
 


### PR DESCRIPTION
Add square root, called sqrt, using math.sqrt to the available functions for test config expressions.