### PR TITLE
addresses Test Series Error of unprintable object

### DIFF
--- a/lib/pavilion/series/test_set.py
+++ b/lib/pavilion/series/test_set.py
@@ -535,7 +535,7 @@ class TestSet:
             for test, error in rp_errors:
                 msg.append("{} - {}".format(test.name, error))
 
-            raise TestSetError(msg)
+            raise TestSetError('\n'.join(msg))
 
     def force_completion(self):
         """Mark all of the tests as complete. We generally do this after


### PR DESCRIPTION
@Paul-Ferrell offered this fix for an exception encountered during production test development. It resolved the issue and returned a useful error from a faulty test config file.