### PR TITLE
Added wrapper feature to schedule section

### DIFF
--- a/docs/tests/scheduling.rst
+++ b/docs/tests/scheduling.rst
@@ -316,3 +316,40 @@ These are set via the ``schedule.chunking.node_selection`` and ``schedule.chunki
         chunking:
           size: 25%
           node_selection: random
+
+.. _tests.scheduling.wrapper:
+
+Wrapper
+-------
+
+On basic scheduler like raw, the ``{{sched.test_cmd}}`` returns an empty string. It can be
+overwritten using the wrapper feature in the schedule section.
+
+.. code-block:: yaml
+
+    basic:
+        scheduler: raw
+        schedule:
+            wrapper: 'mpirun -np 2'
+        run:
+            cmds:
+                # With the schedule wrapper, this will be `mpirun -np 2 ./supermagic -a`
+                - '{{sched.test_cmd}} ./supermagic -a'
+
+You can use the wrapper feature on any scheduler to wrap the scheduler test command and run the
+wrapper command before actually running the intended command.
+
+.. code-block:: yaml
+
+    advanced:
+        scheduler: slurm
+        schedule:
+            wrapper: valgrind
+            partition: standard
+            nodes: 1
+
+        run:
+            cmds:
+                # The run command will be `srun -N1 -p standard valgrind ./supermagic -a`
+                # It will run `valgrind ./supermagic -a` on the allocation
+                - '{{sched.test_cmd}} ./supermagic -a'

--- a/docs/tests/scheduling.rst
+++ b/docs/tests/scheduling.rst
@@ -322,26 +322,12 @@ These are set via the ``schedule.chunking.node_selection`` and ``schedule.chunki
 Wrapper
 -------
 
-On basic scheduler like raw, the ``{{sched.test_cmd}}`` returns an empty string. It can be
-overwritten using the wrapper feature in the schedule section.
-
-.. code-block:: yaml
-
-    basic:
-        scheduler: raw
-        schedule:
-            wrapper: 'mpirun -np 2'
-        run:
-            cmds:
-                # With the schedule wrapper, this will be `mpirun -np 2 ./supermagic -a`
-                - '{{sched.test_cmd}} ./supermagic -a'
-
 You can use the wrapper feature on any scheduler to wrap the scheduler test command and run the
 wrapper command before actually running the intended command.
 
 .. code-block:: yaml
 
-    advanced:
+    basic:
         scheduler: slurm
         schedule:
             wrapper: valgrind
@@ -353,3 +339,20 @@ wrapper command before actually running the intended command.
                 # The run command will be `srun -N1 -p standard valgrind ./supermagic -a`
                 # It will run `valgrind ./supermagic -a` on the allocation
                 - '{{sched.test_cmd}} ./supermagic -a'
+
+When using the ``raw`` scheduler, the ``{{sched.test_cmd}}`` normally returns an empty string. You can 
+use the wrapper setting to control a different scheduler directly.
+
+.. code-block:: yaml
+    shoot_yourself_in_the_foot_mode:
+        scheduler: raw
+        schedule:
+            # Note that generally it's MUCH better to use the Pavilion's scheduling options,
+            # but this allows you to, for example, test the scheduler itself.
+            # Other note - You can use mpirun under slurm by setting ``schedule.slurm.mpi_cmd=mpirun``.
+            wrapper: 'mpirun -np 2'
+        run:
+            cmds:
+                # With the schedule wrapper, this will be `mpirun -np 2 ./supermagic -a`
+                - '{{sched.test_cmd}} ./supermagic -a'
+

--- a/lib/pavilion/schedulers/config.py
+++ b/lib/pavilion/schedulers/config.py
@@ -66,6 +66,9 @@ class ScheduleConfig(yc.KeyedElem):
             'account',
             help_text="The account to use when creating an allocation."),
         yc.StrElem(
+            'wrapper',
+            help_text="Wrapper for the scheduler command."),
+        yc.StrElem(
             'reservation',
             help_text="The reservation to use when creating an allocation. When blank "
                       "nodes in reservations are filtered. Use the keyword 'any' to "
@@ -440,6 +443,7 @@ CONFIG_VALIDATORS = {
     'qos':              None,
     'account':          None,
     'core_spec':        None,
+    'wrapper':          None,
     'reservation':      None,
     'include_nodes':    _validate_node_list,
     'exclude_nodes':    _validate_node_list,
@@ -466,6 +470,7 @@ CONFIG_DEFAULTS = {
     'partition':        None,
     'qos':              None,
     'account':          None,
+    'wrapper':          None,
     'reservation':      None,
     'share_allocation': True,
     'include_nodes':    [],

--- a/lib/pavilion/schedulers/plugins/slurm.py
+++ b/lib/pavilion/schedulers/plugins/slurm.py
@@ -171,8 +171,10 @@ class SlurmVars(SchedulerVariables):
         """Calls the actual test command and then wraps the return with the wrapper
         provided in the schedule section of the configuration."""
 
-        return ' '.join([self._test_cmd(), self._sched_config['wrapper']])
-
+        # Removes all the None values to avoid getting a TypeError while trying to
+        # join two commands
+        return ' '.join(filter(lambda item: item is not None, [self._test_cmd(),
+                               self._sched_config['wrapper']]))
 
 def slurm_float(val):
     """Slurm 'float' values might also be 'N/A'."""

--- a/lib/pavilion/schedulers/plugins/slurm.py
+++ b/lib/pavilion/schedulers/plugins/slurm.py
@@ -126,8 +126,7 @@ class SlurmVars(SchedulerVariables):
         'test_cmd': 'srun -N 5 -w node[05-10],node23 -n 20',
     })
 
-    @dfr_var_method
-    def test_cmd(self):
+    def _test_cmd(self):
         """Construct a cmd to run a process under this scheduler, with the
         criteria specified by this test.
         """
@@ -166,6 +165,13 @@ class SlurmVars(SchedulerVariables):
             cmd.extend(self._sched_config['slurm']['mpirun_extra'])
 
         return ' '.join(cmd)
+
+    @dfr_var_method
+    def test_cmd(self):
+        """Calls the actual test command and then wraps the return with the wrapper
+        provided in the schedule section of the configuration."""
+
+        return ' '.join([self._test_cmd(), self._sched_config['wrapper']])
 
 
 def slurm_float(val):

--- a/lib/pavilion/schedulers/vars.py
+++ b/lib/pavilion/schedulers/vars.py
@@ -154,8 +154,7 @@ each test right before it runs on an allocation in order to un-defer values.
 
         return self._sched_config['partition'] or ''
 
-    @var_method
-    def test_cmd(self):
+    def _test_cmd(self):
         """The command to prepend to a line to kick it off under the scheduler.
 
         This should return the command needed to start one or more MPI processes within
@@ -175,6 +174,13 @@ each test right before it runs on an allocation in order to un-defer values.
         _ = self
 
         return ''
+
+    @var_method
+    def test_cmd(self):
+        """Calls the actual test command and then wraps the result with the wrapper
+        provided in the schedule section of the configuration."""
+ 
+        return ''.join([self._test_cmd(), self._sched_config['wrapper']])
 
     @dfr_var_method
     def tasks_per_node(self) -> int:

--- a/lib/pavilion/schedulers/vars.py
+++ b/lib/pavilion/schedulers/vars.py
@@ -179,7 +179,7 @@ each test right before it runs on an allocation in order to un-defer values.
     def test_cmd(self):
         """Calls the actual test command and then wraps the result with the wrapper
         provided in the schedule section of the configuration."""
- 
+
         return ''.join([self._test_cmd(), self._sched_config['wrapper']])
 
     @dfr_var_method

--- a/lib/pavilion/schedulers/vars.py
+++ b/lib/pavilion/schedulers/vars.py
@@ -180,7 +180,10 @@ each test right before it runs on an allocation in order to un-defer values.
         """Calls the actual test command and then wraps the result with the wrapper
         provided in the schedule section of the configuration."""
 
-        return ''.join([self._test_cmd(), self._sched_config['wrapper']])
+        # Removes all the None values to avoid getting a TypeError while trying to
+        # join two commands
+        return ''.join(filter(lambda item: item is not None, [self._test_cmd(),
+                              self._sched_config['wrapper']]))
 
     @dfr_var_method
     def tasks_per_node(self) -> int:


### PR DESCRIPTION
Example:
```YAML
scheduler: slurm
schedule:
  nodes: 1
  wrapper: valgrind
```
`srun -N1 valgrind <run_cmd>`