### PR TITLE
Fixed argument documentation

### DIFF
--- a/lib/pavilion/commands/result.py
+++ b/lib/pavilion/commands/result.py
@@ -81,8 +81,10 @@ class ResultsCommand(Command):
         parser.add_argument(
             "tests",
             nargs="*",
-            help="The tests to show the results for. Use 'last' to get the "
-                 "results of the last test series you ran on this machine."
+            help="The tests to show the results for. Use 'last' to get the results of the last test"
+                 " series you ran on this machine. Use 'all' to get results of all tests. By " 
+                 "default, 'all' will only display tests newer than 1 day ago, but setting any " 
+                 "filter argument will override that."
         )
         filters.add_test_filter_args(parser)
 

--- a/lib/pavilion/commands/result.py
+++ b/lib/pavilion/commands/result.py
@@ -82,8 +82,8 @@ class ResultsCommand(Command):
             "tests",
             nargs="*",
             help="The tests to show the results for. Use 'last' to get the results of the last test"
-                 " series you ran on this machine. Use 'all' to get results of all tests. By " 
-                 "default, 'all' will only display tests newer than 1 day ago, but setting any " 
+                 " series you ran on this machine. Use 'all' to get results of all tests. By "
+                 "default, 'all' will only display tests newer than 1 day ago, but setting any "
                  "filter argument will override that."
         )
         filters.add_test_filter_args(parser)

--- a/lib/pavilion/commands/status.py
+++ b/lib/pavilion/commands/status.py
@@ -14,11 +14,7 @@ class StatusCommand(Command):
     """Prints the status of a set of tests."""
 
     def __init__(self):
-        super().__init__('status', 'Check the status of a test, list of tests,'
-                                   ' or test series. You may also specify "all" as '
-                                   'the test id, to get the status of all tests. The '
-                                   'default "all" filter gives your recent tests, but setting '
-                                   'any filter argumument overrides that.',
+        super().__init__('status', 'Check the status of a test, list of tests, or test series.',
                          short_help="Get status of tests.")
 
     def _setup_arguments(self, parser):
@@ -35,9 +31,10 @@ class StatusCommand(Command):
             help='Show the status note.')
         parser.add_argument(
             'tests', nargs='*', action='store',
-            help="The name(s) of the tests to check.  These may be any mix of "
-                 "test IDs and series IDs. Lists tests in the last series you "
-                 "ran by default. Use 'all' to show all tests."
+            help="The name(s) of the tests to check. These may be any mix of test IDs and series "
+                 "IDs. Lists tests in the last series you ran by default. Use 'all' to show all "
+                 "tests. By default, 'all' will only display status of tests newer than 1 day ago, "
+                 " but setting any filter argument will override that."
         )
         output_mode = parser.add_mutually_exclusive_group()
         output_mode.add_argument(


### PR DESCRIPTION
Fixed the docstrings for the `pav results` and `pav status` commands.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
