### PR TITLE
`collections` directory

### DIFF
--- a/lib/pavilion/cmd_utils.py
+++ b/lib/pavilion/cmd_utils.py
@@ -214,7 +214,7 @@ def arg_filtered_series(pav_cfg: config.PavConfig, args: argparse.Namespace,
         return matching_series
 
 
-def read_test_files(files: List[str], pav_cfg) -> List[str]:
+def read_test_files(pav_cfg, files: List[str]) -> List[str]:
     """Read the given files which contain a list of tests (removing comments)
     and return a list of test names."""
 

--- a/lib/pavilion/cmd_utils.py
+++ b/lib/pavilion/cmd_utils.py
@@ -214,13 +214,15 @@ def arg_filtered_series(pav_cfg: config.PavConfig, args: argparse.Namespace,
         return matching_series
 
 
-def read_test_files(files: List[str]) -> List[str]:
+def read_test_files(files: List[str], pav_cfg) -> List[str]:
     """Read the given files which contain a list of tests (removing comments)
     and return a list of test names."""
 
     tests = []
     for path in files:
         path = Path(path)
+        if not path.is_absolute():
+            path = get_collection_path(pav_cfg, path)
         try:
             with path.open() as file:
                 for line in file:
@@ -234,6 +236,27 @@ def read_test_files(files: List[str]) -> List[str]:
                              .format(path, err))
 
     return tests
+
+
+def get_collection_path(pav_cfg, collection) -> Path:
+    """Read the given list of collection files and return full absolute paths."""
+
+    # Check if this collection exists in one of the defined config dirs
+    for config in pav_cfg['configs'].items():
+        _, config_path = config
+        collection_path = config_path.path / 'collections' / collection
+        if collection_path.exists():
+            return collection_path
+
+    # If the previous loop completes, then check the current working directory for the collection
+    cwd_collection = Path.cwd() / collection
+    if cwd_collection.exists():
+        return cwd_collection
+
+    # If it reaches this point, then the collection does not exist in any of the defined config dirs
+    # nor the current working directory
+    raise ValueError("Cannot find collection '{}' in the config dirs nor the current dir."
+                     .format(collection))
 
 
 def test_list_to_paths(pav_cfg, req_tests, errfile=None) -> List[Path]:

--- a/lib/pavilion/commands/config.py
+++ b/lib/pavilion/commands/config.py
@@ -244,7 +244,7 @@ class ConfigCommand(Command):
             raise ConfigCmdError("Error writing config file at '{}'"
                                  .format(config_file_path), err)
 
-        for subdir in 'hosts', 'modes', 'tests', 'test_src', 'plugins':
+        for subdir in 'hosts', 'modes', 'tests', 'test_src', 'plugins', 'collections':
             subdir = path/subdir
             try:
                 subdir.mkdir()

--- a/lib/pavilion/commands/run.py
+++ b/lib/pavilion/commands/run.py
@@ -134,7 +134,7 @@ class RunCommand(Command):
 
         tests = args.tests
         try:
-            tests.extend(cmd_utils.read_test_files(args.files, pav_cfg))
+            tests.extend(cmd_utils.read_test_files(pav_cfg, args.files))
         except ValueError as err:
             output.fprint(sys.stdout, "Error reading given test list files.\n{}"
                           .format(err))

--- a/lib/pavilion/commands/run.py
+++ b/lib/pavilion/commands/run.py
@@ -134,7 +134,7 @@ class RunCommand(Command):
 
         tests = args.tests
         try:
-            tests.extend(cmd_utils.read_test_files(args.files))
+            tests.extend(cmd_utils.read_test_files(args.files, pav_cfg))
         except ValueError as err:
             output.fprint(sys.stdout, "Error reading given test list files.\n{}"
                           .format(err))

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -403,7 +403,7 @@ class ShowCommand(Command):
             collection_dir = Path(config_path.path / 'collections')
             if collection_dir.exists() and collection_dir.is_dir():
                 for col_file in os.listdir(collection_dir):
-                    collections.append({'collection': col_file, 
+                    collections.append({'collection': col_file,
                                         'path': Path(collection_dir / col_file)})
 
         output.draw_table(self.outfile, fields=['collection', 'path'], rows=collections,

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -3,8 +3,10 @@
 import argparse
 import errno
 import fnmatch
+import os
 import pprint
 import sys
+from pathlib import Path
 from typing import Union
 
 import pavilion.errors
@@ -75,6 +77,12 @@ class ShowCommand(Command):
             in the order given. Tests in higher directories supersede those
             in lower. Plugins, however, are resolved according to internally
             defined priorities."""
+        )
+
+        subparsers.add_parser(
+            'collections',
+            aliases=['collection'],
+            help="List collections found in config dirs."
         )
 
         func_group = subparsers.add_parser(
@@ -383,6 +391,28 @@ class ShowCommand(Command):
             fields=['label', 'path', 'working_dir'],
             rows=pav_cfg.configs.values(),
             title="Config directories by priority."
+        )
+
+    @sub_cmd('collection')
+    def _collections_cmd(self, pav_cfg, _):
+        """List all files found in the collections directories in all config directories."""
+
+        collections = []
+
+        for config in pav_cfg['configs'].items():
+            _, config_path = config
+            collection_dir = Path(config_path.path / 'collections')
+            if collection_dir.exists() and collection_dir.is_dir():
+                for col_file in os.listdir(collection_dir):
+                    collections.append(
+                        {'collection': col_file, 'path': Path(collection_dir / col_file)}
+                    )
+
+        output.draw_table(
+            self.outfile,
+            fields=['collection', 'path'],
+            rows=collections,
+            title="Available collections and paths."
         )
 
     @sub_cmd('function', 'func')

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -398,22 +398,16 @@ class ShowCommand(Command):
         """List all files found in the collections directories in all config directories."""
 
         collections = []
-
         for config in pav_cfg['configs'].items():
             _, config_path = config
             collection_dir = Path(config_path.path / 'collections')
             if collection_dir.exists() and collection_dir.is_dir():
                 for col_file in os.listdir(collection_dir):
-                    collections.append(
-                        {'collection': col_file, 'path': Path(collection_dir / col_file)}
-                    )
+                    collections.append({'collection': col_file, 
+                                        'path': Path(collection_dir / col_file)})
 
-        output.draw_table(
-            self.outfile,
-            fields=['collection', 'path'],
-            rows=collections,
-            title="Available collections and paths."
-        )
+        output.draw_table(self.outfile, fields=['collection', 'path'], rows=collections,
+                          title="Available collections and paths.")
 
     @sub_cmd('function', 'func')
     def _functions_cmd(self, _, args):

--- a/lib/pavilion/commands/view.py
+++ b/lib/pavilion/commands/view.py
@@ -76,7 +76,7 @@ class ViewCommand(run.RunCommand):
 
         res = resolver.TestConfigResolver(pav_cfg)
 
-        tests.extend(cmd_utils.read_test_files(args.files))
+        tests.extend(cmd_utils.read_test_files(args.files, pav_cfg))
 
         try:
             proto_tests = res.load(

--- a/lib/pavilion/commands/view.py
+++ b/lib/pavilion/commands/view.py
@@ -76,7 +76,7 @@ class ViewCommand(run.RunCommand):
 
         res = resolver.TestConfigResolver(pav_cfg)
 
-        tests.extend(cmd_utils.read_test_files(args.files, pav_cfg))
+        tests.extend(cmd_utils.read_test_files(pav_cfg, args.files))
 
         try:
             proto_tests = res.load(

--- a/test/data/pav_config_dir/collections/testlist.txt
+++ b/test/data/pav_config_dir/collections/testlist.txt
@@ -1,0 +1,1 @@
+hello_world.hello

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -1,7 +1,6 @@
 import io
 
 from pavilion import arguments
-from pavilion import cmd_utils
 from pavilion import commands
 from pavilion import plugins
 from pavilion.status_file import STATES

--- a/test/tests/run_cmd_tests.py
+++ b/test/tests/run_cmd_tests.py
@@ -1,6 +1,7 @@
 import io
 
 from pavilion import arguments
+from pavilion import cmd_utils
 from pavilion import commands
 from pavilion import plugins
 from pavilion.status_file import STATES
@@ -181,3 +182,18 @@ class RunCmdTests(PavTestCase):
             'run', 'hello_world.hello*two'
         ])
         self.assertNotEqual(run_cmd.run(self.pav_cfg, args), 0)
+
+    def test_run_file(self):
+        """Check that the -f argument for pav run works. """
+
+        arg_parser = arguments.get_parser()
+
+        # pass a collection name to -f (not an absolute path) 
+        args = arg_parser.parse_args([
+            'run',
+            '-f', 'testlist.txt',
+        ])
+
+        run_cmd = commands.get_command(args.command_name)
+
+        self.assertEqual(run_cmd.run(self.pav_cfg, args), 0)


### PR DESCRIPTION
Resolves #600 

1. Added `collections` as a config directory
2. Can pass relative path to `-f` (must be relative to `collections` dir or in the current directory)
3. `pav show collections` will display collections and paths

- [x] add unit test

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
