### PR TITLE
Added format key to results_parse yc.

### DIFF
--- a/lib/pavilion/result/parse.py
+++ b/lib/pavilion/result/parse.py
@@ -70,6 +70,31 @@ class KeySet:
 
 ProcessFileArgs = NewType('ProcessFileArgs', Tuple[Path, List[KeySet]])
 
+def format_results(result_val, format_spec):
+    """Format the result value according to the format spec.
+    :param result_val: The value to format.
+    :param format_spec: The format spec.
+    :return: The formatted value.
+    """
+
+    #Check if result_val is a string or bool.
+    if isinstance(result_val, (str, bool)):
+        return result_val
+
+    #Check if result_val is numeric.
+    if isinstance(result_val, (int, float)):
+        return format_spec.format(result_val)
+
+    if isinstance(result_val, (list, set)):
+        formatted_result=[]
+        for res_v in result_val:
+            if isinstance(res_v, (int, float)):
+                formatted_result.append(format_spec.format(res_v))
+            else:
+                formatted_result.append(res_v)
+        
+        return formatted_result
+
 
 def parse_results(pav_cfg, test, results: Dict, base_log: IndentedLog) -> None:
     """Parse the results of the given test using all the result parsers
@@ -107,6 +132,8 @@ configured for that test.
     per_file = {}
     # Action values by key
     actions = {}
+    # Format values by key
+    formats = {}
 
     # A list of encountered error messages.
     errors = []
@@ -120,6 +147,7 @@ configured for that test.
 
             per_file[key] = rconf['per_file']
             actions[key] = rconf['action']
+            formats[key] = rconf['format']
 
             for file_glob in rconf['files']:
                 base_glob = file_glob
@@ -190,7 +218,7 @@ configured for that test.
     for key, per_file_name in per_file.items():
         per_file_func = PER_FILES[per_file_name]  # type: per_first
         action_name = actions[key]
-        presults = ordered_filed_results[key]
+        presults = format_results(ordered_filed_results[key], formats[key])
 
         try:
             log("Applying per-file option '{}' and action '{}' to key '{}'."

--- a/lib/pavilion/result_parsers/base_classes.py
+++ b/lib/pavilion/result_parsers/base_classes.py
@@ -211,7 +211,7 @@ deferred args. On error, should raise a ResultParserError.
             args[key] = kwargs[key]
         kwargs = args
 
-        base_keys = ('action', 'per_file', 'files', 'match_select',
+        base_keys = ('action', 'per_file', 'files', 'format', 'match_select',
                      'for_lines_matching', 'preceded_by')
 
         for key in base_keys:
@@ -313,6 +313,10 @@ deferred args. On error, should raise a ResultParserError.
             help_text="Path to the file/s that this result parser "
                       "will examine. Each may be a file glob,"
                       "such as '*.log'"),
+        yc.StrElem(
+            "format",
+            help_text="Python string format 'eg. {:.3f}' to store the result."
+        ),
         yc.StrElem(
             "per_file",
             help_text=(
@@ -470,6 +474,7 @@ Example: ::
     _DEFAULTS = {
         'per_file':           PER_FIRST,
         'action':             ACTION_STORE,
+        'format':             '{.3f}',
         'files':              ['../run.log'],
         'match_select':       MATCH_FIRST,
         'for_lines_matching': '',


### PR DESCRIPTION
On the same level as 'action'.  This avoids printing results with an absurd number of digits to the terminal. And facilitates displaying results as the user desires.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md

Am I supposed to fill that out?

Anyway, I'm missing the documentation to the docs and typed function arguments.  I'll fill those in, but now I want to see if it works.  This feature adds a 'format' key to a result which will store and display the result as the user intends.  It's inspired by this:

![Ugly_pav_output](https://github.com/hpc/pavilion2/assets/43071310/c9524ffb-e36c-44e8-b921-26d47200c944)

Which is ugly and doesn't match the format I'm visually comparing the results to, which is annoying.