### PR TITLE
Get the Stream example usable, and fix regex issues.

### DIFF
--- a/examples/acceptance/tests/stream.yaml
+++ b/examples/acceptance/tests/stream.yaml
@@ -1,5 +1,5 @@
 base:
-    subtitle: '{{compilers}}} {{mpis}} OMP_NUM_THREADS={{omp_num_threads}} GOMP_CPU_AFFINITY=0-{{omp_num_threads-1}}'
+    subtitle: '{{compilers}} {{mpis}} OMP_NUM_THREADS={{omp_num_threads}} GOMP_CPU_AFFINITY=0-{{omp_num_threads-1}}'
     summary: 'Runs STREAM Memory Benchmark'
     doc: |
 
@@ -14,22 +14,22 @@ base:
         share_allocation: false
 
     variables:
-        # each array must be at least 4x the size of the sum of all the last-level caches or 
+        # each array must be at least 4x the size of the sum of all the last-level caches or
         # 1 million, whichever is larger (see doc for calculations). 10 M is the default in the code
         array_size?: 10000000
         # how many times to run each kernel. 2 is the minimum
-        ntimes?: 2
+        NTIMES?: 2
         # Other compiler options such as --mcmodel=medium may be necessary for large memory runs
         other_compile_opts?: '--mcmodel=medium'
         omp_num_threads?: 2
 
-    permute_on: 
+    permute_on:
         - compilers
         - mpis
         - omp_num_threads
 
     build:
-        source_path: stream
+        source_path: stream.c
         source_url: https://www.cs.virginia.edu/stream/FTP/Code/stream.c
         on_nodes: true
         modules:
@@ -56,7 +56,7 @@ base:
             result:
                 regex: 'Solution Validates:'
                 action: store_true
-                files: '*stream'
+                files: '*_stream'
                 per_file: all
             ARRAY_SIZE:
                 regex: 'N=(.*)'
@@ -68,29 +68,29 @@ base:
                 regex: '(.B/s)'
                 action: store
                 match_select: last
-                files: '*stream'
+                files: '*_stream'
                 per_file: name
             copy:
                 regex: '^Copy: *([0-9\.]*) '
                 action: store
                 match_select: last
-                files: '*stream'
+                files: '*_stream'
                 per_file: name
             scale:
                 regex: '^Scale: *([0-9\.]*) '
                 action: store
                 match_select: last
-                files: '*stream'
+                files: '*_stream'
                 per_file: name
             add:
                 regex: '^Add: *([0-9\.]*) '
                 action: store
                 match_select: last
-                files: '*stream'
+                files: '*_stream'
                 per_file: name
             triad:
                 regex: '^Triad: *([0-9\.]*) '
                 action: store
                 match_select: last
-                files: '*stream'
+                files: '*_stream'
                 per_file: name


### PR DESCRIPTION
I ran into some issues attempting to use the stream example:

- extra } in the  subtitle.
- source path was incorrect for a c file
- regex files were reading the binary(and the source before the file was renamed) and as such would pass because the result string was in there.
- capitalized the NTIMES so it matched the use in the build cmds