### PR TITLE
If the run is build only set schedule.nodes=1.

### DIFF
--- a/lib/pavilion/series/test_set.py
+++ b/lib/pavilion/series/test_set.py
@@ -201,6 +201,14 @@ class TestSet:
             'not_if': self.not_if
         }
 
+        if build_only:
+            for override in self.overrides:
+                if override.startswith('schedule.nodes'):
+                    self.overrides.remove(override)
+                    break
+
+            self.overrides.append('schedule.nodes=1')
+
         cfg_resolver = TestConfigResolver(
             self.pav_cfg,
             op_sys=self.op_sys,


### PR DESCRIPTION
Overrides the any overrides or internal calculations and adds schedule.nodes=1 to the list so that the scheduler can't run out of nodes during build_only run (even if building 'on_nodes' you shouldn't need more than 1.

- [x] Code is generally sensical and well commented
- [x] Variable/function names all telegraph their purpose and contents
- [x] Functions/classes have useful doc strings
- [x] Function arguments are typed
- [x] Added/modified unit tests to cover changes.
- [x] New features have documentation added to the docs.
- [x] New features and backwards compatibility breaks are noted in the RELEASE.md

Resolves #712.  Still checks for node availability, but only asks for 1 node.
