### PR TITLE
Error reporting fix

### DIFF
--- a/lib/pavilion/errors.py
+++ b/lib/pavilion/errors.py
@@ -99,7 +99,7 @@ class PavilionError(RuntimeError):
                 try:
                     with open(ctx_mark.name) as yaml_file:
                         file_lines = yaml_file.readlines()
-                except OSError:
+                except (OSError, AttributeError):
                     lines.append(indent + str(next_exc.problem))
                     break
 


### PR DESCRIPTION
Except AttributeErrors in error.py:pformat so that the original error still gets reported if there's no ctx_mark.name property. This doesn't fix the issue of that property being None, but it does give sensible errors that a user can debug.

I created an error by inserting a tab into a test config:

## Error before change

Created Test Series cmdline.
Error loading test configs for test set 'parthenon'
Unknown error running command run. 'NoneType' object has no attribute
'name'
Traceback (most recent call last):
  File "/usr/projects/hpcml/test/dmagee/venado-acceptance/pav_src/lib/pavilion/main.py", line 115, in run_cmd
    return cmd.run(pav_cfg, args)
  File "/usr/projects/hpcml/test/dmagee/venado-acceptance/pav_src/lib/pavilion/commands/run.py", line 196, in run
    local_builds_only=local_builds_only)
  File "/usr/projects/hpcml/test/dmagee/venado-acceptance/pav_src/lib/pavilion/series/series.py", line 438, in run
    rebuild=rebuild, local_builds_only=local_builds_only)
  File "/usr/projects/hpcml/test/dmagee/venado-acceptance/pav_src/lib/pavilion/series/series.py", line 479, in _run_set
    for test_batch in test_set.make_iter(build_only, rebuild, local_builds_only):
  File "/usr/projects/hpcml/test/dmagee/venado-acceptance/pav_src/lib/pavilion/series/test_set.py", line 237, in make_iter
    '{} - {}'.format(error.request.request, error.pformat()))
  File "/usr/projects/hpcml/test/dmagee/venado-acceptance/pav_src/lib/pavilion/errors.py", line 100, in pformat
    with open(ctx_mark.name) as yaml_file:
AttributeError: 'NoneType' object has no attribute 'name'
Traceback logged to None

## Error after change

Created Test Series cmdline.
Error loading test configs for test set 'parthenon'
parthenon - Suite config '/usr/projects/hpcml/test/dmagee/venado-
acceptance/tests/parthenon.yaml' has a YAML Error
  while scanning for the next token
  found character '\t' that cannot start any token
Error making tests for series 's4'.
  Error creating tests for test set parthenon.
    Suite config '/usr/projects/hpcml/test/dmagee/venado-
      acceptance/tests/parthenon.yaml' has a YAML Error
      while scanning for the next token
      found character '\t' that cannot start any token

Code review checklist:

- [x] Code is generally sensical and well commented
- [x] Variable/function names all telegraph their purpose and contents
- [x] Functions/classes have useful doc strings
- [x] Function arguments are typed
- [x] Added/modified unit tests to cover changes.
- [x] New features have documentation added to the docs.
- [x] New features and backwards compatibility breaks are noted in the RELEASE.md
