### PR TITLE
Preserve extra files permissions

### DIFF
--- a/lib/pavilion/builder.py
+++ b/lib/pavilion/builder.py
@@ -438,6 +438,8 @@ class TestBuilder:
 
                             try:
                                 self.path.rename(self.fail_path)
+                                tracker.warn("FAILED_BUILD_MOVED to {}"
+                                             .format(self.fail_path))
                             except FileNotFoundError as err:
                                 tracker.error(
                                     "Failed to move build {} from {} to "
@@ -543,6 +545,7 @@ class TestBuilder:
             with self.tmp_log_path.open('w') as build_log:
                 # Build scripts take the test id as a first argument.
                 cmd = [self._script_path.as_posix(), test_id]
+                build_log.write("FAIL PATH: {}".format(self.fail_path))
                 proc = subprocess.Popen(cmd,
                                         cwd=build_dir.as_posix(),
                                         stdout=build_log,


### PR DESCRIPTION
Pavilion wasn't honoring extra files permissions, fixed that by getting the extra file permissions and modifying the file after moving it in _setup_build_dir. This is necessary for executable wrapper scripts which are particularly essential for gpu runs where the target application needs to run on one gpu per process.

Also added the failed return code to the status tracker for failed builds, and fixed the format in the tracker call for failed build moves.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
