### PR TITLE
Fixed on_node failed build non-stopping problem. Now builds with on_n…

### DIFF
--- a/lib/pavilion/builder.py
+++ b/lib/pavilion/builder.py
@@ -96,7 +96,9 @@ class TestBuilder:
 
         self.path = working_dir/'builds'/self.name  # type: Path
 
-        if not self.path.exists():
+        current_status = status.current()
+
+        if not self.path.exists() and "ERROR" not in current_status.state:
             status.set(state=STATES.BUILD_CREATED, note="Builder created.")
 
         self.tmp_log_path = self.path.with_suffix('.log')

--- a/lib/pavilion/commands/_run.py
+++ b/lib/pavilion/commands/_run.py
@@ -78,7 +78,7 @@ class _RunCommand(Command):
                 if not test.build_local:
                     if not test.build():
                         fprint(sys.stdout, "Test {} failed to build.".format(test.full_id))
-
+                        raise Exception
             except Exception:
                 test.status.set(
                     STATES.BUILD_ERROR,


### PR DESCRIPTION
Fixes issue #763. Raises exception on non test.build_local build failure which stops pavilion from running the test anyway. And stops non test.build_local runs from writing `BUILD_CREATED` lines to status over and over when this test is queried.

There could probably be a better condition to stop writing BUILD_CREATED statuses. But in this case, if the run is completed or has an error status, it will keep that status.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
