### PR TITLE
Fix Result table formatting

### DIFF
--- a/lib/pavilion/commands/result.py
+++ b/lib/pavilion/commands/result.py
@@ -247,7 +247,7 @@ class ResultsCommand(Command):
                 fields=fields,
                 rows=flat_sorted_results,
                 title=title_str,
-                default_format=lambda x: format_numeric(x)
+                default_format=format_numeric
             )
 
         if args.show_log:

--- a/lib/pavilion/commands/result.py
+++ b/lib/pavilion/commands/result.py
@@ -36,33 +36,11 @@ def _num_digits(n: int) -> int: # pylint: disable=invalid-name
     return floor(log10(n)) + 1
 
 
-def format_numeric(value: Any, digits: Optional[int]) -> str:
-    if digits is None:
-        return str(value)
-
-    sci_fmt = '{' + f':.{digits-1}e' + '}'
-
-    if isinstance(value, int):
-        if _num_digits(value) > digits:
-            res = sci_fmt.format(value)
-        else:
-            res = str(value)
-    elif isinstance(value, float):
-        if abs(value) < 10**-(digits - 1):
-            res = sci_fmt.format(value)
-        else:
-            res = str(round(value, digits - 1))
+def format_numeric(value: Any) -> str:
+    if isinstance(value, int) or isinstance(value, float):
+        return "{:g}".format(value)
     else:
         return str(value)
-
-    # Remove leading zeros in exponent, as well as + sign, if present
-    pos_regex = 'e\+0*'
-    neg_regex = 'e-0*'
-
-    res = re.sub(pos_regex, "e", res)
-    res = re.sub(neg_regex, "e-", res)
-
-    return res
 
 
 class ResultsCommand(Command):
@@ -140,13 +118,6 @@ class ResultsCommand(Command):
                  " series you ran on this machine. Use 'all' to get results of all tests. By "
                  "default, 'all' will only display tests newer than 1 day ago, but setting any "
                  "filter argument will override that."
-        )
-        parser.add_argument(
-            '-d', '--max-digits', dest="max_digits", default=5,
-            help="The maximum number of digits to display when formatting floating point values. If"
-                 " set, numbers much larger or much smaller than 1 are displayed in scientific "
-                 "notation with the specified precision, and numbers near 1 are truncated. "
-                 "Defaults to 5 digits."""
         )
         filters.add_test_filter_args(parser)
 
@@ -276,7 +247,7 @@ class ResultsCommand(Command):
                 fields=fields,
                 rows=flat_sorted_results,
                 title=title_str,
-                default_format=lambda x: format_numeric(x, args.max_digits)
+                default_format=lambda x: format_numeric(x)
             )
 
         if args.show_log:

--- a/test/tests/output_tests.py
+++ b/test/tests/output_tests.py
@@ -86,14 +86,3 @@ class OutputTests(PavTestCase):
 
         self.assertLess(timer/count, .3, "Per table draw speed exceed 30 ms")
 
-
-    def test_float_formatting(self):
-        fields = ['data']
-        rows = [{'data': 5.123412341234}, {'data': 5123049812734}, {'data': 0.000000001234},
-             {'data': 42}, {'data': 0}, {'data': -9000}, {'data': 2.718}, {'data': -3.14}, {'data': 'bricks'}]
-
-        rows = output.dt_format_rows(rows, fields, {}, lambda x: result.format_numeric(x, 5))
-        expected = ['5.1234', '5.1230e12', '1.2340e-9', '42', '0', '-9000', '2.718', '-3.14', 'bricks']
-        actual = list(map(lambda x: x['data'], rows))
-
-        self.assertEqual(expected, actual)


### PR DESCRIPTION
Before change the -d flag doesn't work because the input is a string.

``` bash
~ pav results -k nnodes,zcycles_wsec,~name,~started,nx,compilers.name --sort-by=-zcycles_wsec -d 2 s5
Unknown error running command results. unsupported operand type(s) for -: 'str' and 'int'
Traceback (most recent call last):
  File "/users/dmagee/venado-acceptance/pav_src/lib/pavilion/main.py", line 115, in run_cmd
    return cmd.run(pav_cfg, args)
  File "/users/dmagee/venado-acceptance/pav_src/lib/pavilion/commands/result.py", line 279, in run
    default_format=lambda x: format_numeric(x, args.max_digits)
  File "/users/dmagee/venado-acceptance/pav_src/lib/pavilion/output.py", line 571, in draw_table
    rows = dt_format_rows(rows, fields, field_info, default_format)
  File "/users/dmagee/venado-acceptance/pav_src/lib/pavilion/output.py", line 702, in dt_format_rows
    formatted_data = col_format(data)
  File "/users/dmagee/venado-acceptance/pav_src/lib/pavilion/commands/result.py", line 279, in <lambda>
    default_format=lambda x: format_numeric(x, args.max_digits)
  File "/users/dmagee/venado-acceptance/pav_src/lib/pavilion/commands/result.py", line 43, in format_numeric
    sci_fmt = '{' + f':.{digits-1}e' + '}'
TypeError: unsupported operand type(s) for -: 'str' and 'int'
Traceback logged to None
```

Even if you add `type=int` to the argument it doesn't work. I added this in place and tried it with results below:

``` bash
pav results -k nnodes,zcycles_wsec,~name,~started,nx,compilers.name --sort-by=-zcycles_wsec -d 2 s5
 Test Results: s5.
----+--------+--------+--------------+------+----------------
 Id | Result | Nnodes | Zcycles wsec | Nx   | Compilers.name
----+--------+--------+--------------+------+----------------
 26 | PASS   | 512    | 1920000000.0 | 2128 | cce
 17 | PASS   | 512    | 1780000000.0 | 2128 | gcc-native
 25 | PASS   | 256    | 1140000000.0 | 1696 | cce
 16 | PASS   | 256    | 1110000000.0 | 1696 | gcc-native
 24 | PASS   | 128    | 825000000.0  | 1344 | cce
 15 | PASS   | 128    | 741000000.0  | 1344 | gcc-native
 23 | PASS   | 64     | 609000000.0  | 1072 | cce
 14 | PASS   | 64     | 564000000.0  | 1072 | gcc-native
 22 | PASS   | 32     | 463000000.0  | 848  | cce
 13 | PASS   | 32     | 413000000.0  | 848  | gcc-native
 21 | PASS   | 16     | 321000000.0  | 672  | cce
 12 | PASS   | 16     | 299000000.0  | 672  | gcc-native
 20 | PASS   | 8      | 151000000.0  | 528  | cce
 11 | PASS   | 8      | 146000000.0  | 528  | gcc-native
 10 | PASS   | 4      | 131000000.0  | 416  | gcc-native
 19 | PASS   | 4      | 122000000.0  | 416  | cce
 18 | PASS   | 1      | 40000000.0   | 272  | cce
 9  | PASS   | 1      | 38600000.0   | 272  | gcc-native
 ```

It works now though, scrap the cl argument and use the `g` format flag for any numeric fields, otherwise return the string.

``` bash
pav results -k nnodes,zcycles_wsec,~name,~started,nx,compilers.name --sort-by=-zcycles_wsec
 Test Results: s5.
----+--------+--------+--------------+------+----------------
 Id | Result | Nnodes | Zcycles wsec | Nx   | Compilers.name
----+--------+--------+--------------+------+----------------
 26 | PASS   | 512    | 1.92e+09     | 2128 | cce
 17 | PASS   | 512    | 1.78e+09     | 2128 | gcc-native
 25 | PASS   | 256    | 1.14e+09     | 1696 | cce
 16 | PASS   | 256    | 1.11e+09     | 1696 | gcc-native
 24 | PASS   | 128    | 8.25e+08     | 1344 | cce
 15 | PASS   | 128    | 7.41e+08     | 1344 | gcc-native
 23 | PASS   | 64     | 6.09e+08     | 1072 | cce
 14 | PASS   | 64     | 5.64e+08     | 1072 | gcc-native
 22 | PASS   | 32     | 4.63e+08     | 848  | cce
 13 | PASS   | 32     | 4.13e+08     | 848  | gcc-native
 21 | PASS   | 16     | 3.21e+08     | 672  | cce
 12 | PASS   | 16     | 2.99e+08     | 672  | gcc-native
 20 | PASS   | 8      | 1.51e+08     | 528  | cce
 11 | PASS   | 8      | 1.46e+08     | 528  | gcc-native
 10 | PASS   | 4      | 1.31e+08     | 416  | gcc-native
 19 | PASS   | 4      | 1.22e+08     | 416  | cce
 18 | PASS   | 1      | 4e+07        | 272  | cce
 9  | PASS   | 1      | 3.86e+07     | 272  | gcc-native
 ```

Code review checklist:

- [x] Code is generally sensical and well commented
- [x] Variable/function names all telegraph their purpose and contents
- [x] Functions/classes have useful doc strings
- [x] Function arguments are typed
- [x] Added/modified unit tests to cover changes.
- [x] New features have documentation added to the docs.
- [x] New features and backwards compatibility breaks are noted in the RELEASE.md
