### PR TITLE
Fix max-digits in output formatting to convert input to int

### DIFF
--- a/lib/pavilion/commands/result.py
+++ b/lib/pavilion/commands/result.py
@@ -142,7 +142,7 @@ class ResultsCommand(Command):
                  "filter argument will override that."
         )
         parser.add_argument(
-            '-d', '--max-digits', dest="max_digits", default=5,
+            '-d', '--max-digits', dest="max_digits", default=5, type=int,
             help="The maximum number of digits to display when formatting floating point values. If"
                  " set, numbers much larger or much smaller than 1 are displayed in scientific "
                  "notation with the specified precision, and numbers near 1 are truncated. "


### PR DESCRIPTION
Output formatting code took max-digits argument as a string, and never converted it to an int, resulting in an eventual TypeError. This commit simply modifies the argument parser to automatically convert the value into an integer.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
