### PR TITLE
The 'errors' record for series now counts all errors for tests/series.

### DIFF
--- a/lib/pavilion/series/info.py
+++ b/lib/pavilion/series/info.py
@@ -149,21 +149,30 @@ class SeriesInfoBase(Mapping):
 
         status_obj = self._get_status_file()
 
+        error_values = [
+            'ERROR',
+            'CANCELLED',
+            'TIMEOUT',
+            ]
+
         errors = 0
         for status in status_obj.history():
-            if status.state in (status_file.SERIES_STATES.ERROR,
-                                status_file.SERIES_STATES.BUILD_ERROR,
-                                status_file.SERIES_STATES.CREATION_ERROR,
-                                status_file.SERIES_STATES.KICKOFF_ERROR):
-                errors += 1
+            for error_val in error_values:
+                if error_val in status.state:
+                    errors += 1
+                    break
 
         for test_path in self._tests:
             test_info = self.test_info(test_path)
             if test_info is None:
                 continue
 
-            if test_info.result == TestRun.ERROR:
-                errors += 1
+            # Look for any bad test states
+            for error_val in error_values:
+                for state in test_info.state_history:
+                    if error_val in state.state:
+                        errors += 1
+                        break
 
         return errors
 

--- a/test/tests/series_tests.py
+++ b/test/tests/series_tests.py
@@ -291,6 +291,10 @@ class SeriesTests(PavTestCase):
             else:
                 self.assertEqual(test.result, None)
 
+        # Check that the info object lists the proper number of errors.
+        series_info = series.SeriesInfo(self.pav_cfg, series_obj.path)
+        self.assertEqual(series_info.errors, 9)
+
     def test_series_conditionals_only_if_ok(self):
         """Test that adding a conditional that always matches produces tests that
         run when expected."""


### PR DESCRIPTION
I've noticed that the 'errors' number when running `pav series status` doesn't include all test errors, like timeouts and other errors. It should with this change.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
