### PR TITLE
Remove `.yaml` suffix from test names

### DIFF
--- a/lib/pavilion/config.py
+++ b/lib/pavilion/config.py
@@ -264,7 +264,7 @@ class PavConfig(PavConfigDict):
 
             if tests_dir.exists():
                 tests = [file for file in tests_dir.iterdir() if file.suffix.lower() == ".yaml"]
-                names = [test.name for test in tests]
+                names = [test.stem for test in tests]
                 labels = [label] * len(tests)
 
                 suite_infos.extend(zip(labels, names, tests))


### PR DESCRIPTION
This commit fixes a regression in which the `.yaml` suffix is incorrectly appended to the names of tests, introduced when support for suites directories was added.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
