### PR TITLE
Prevent tests from transitioning to BUILD_CREATED state after failure

### DIFF
--- a/lib/pavilion/builder.py
+++ b/lib/pavilion/builder.py
@@ -103,7 +103,7 @@ class TestBuilder:
 
         current_status = status.current()
 
-        if not self.path.exists() and "ERROR" not in current_status.state:
+        if not self.path.exists() and not STATES.is_fatal(current_status.state):
             status.set(state=STATES.BUILD_CREATED, note="Builder created.")
 
         self.tmp_log_path = self.path.with_suffix('.log')

--- a/lib/pavilion/series/test_set.py
+++ b/lib/pavilion/series/test_set.py
@@ -630,7 +630,7 @@ class TestSet:
 
         for test in tests:
             if (test.status.current().state not in
-                    (STATES.BUILD_FAILED, STATES.BUILD_ERROR)):
+                    (STATES.BUILD_FAILED, STATES.BUILD_ERROR, STATE.ABORTED)):
                 test.status.set(
                     STATES.ABORTED,
                     "Run aborted due to failures in other builds.")

--- a/lib/pavilion/series/test_set.py
+++ b/lib/pavilion/series/test_set.py
@@ -630,7 +630,7 @@ class TestSet:
 
         for test in tests:
             if (test.status.current().state not in
-                    (STATES.BUILD_FAILED, STATES.BUILD_ERROR, STATE.ABORTED)):
+                    (STATES.BUILD_FAILED, STATES.BUILD_ERROR, STATES.ABORTED)):
                 test.status.set(
                     STATES.ABORTED,
                     "Run aborted due to failures in other builds.")

--- a/lib/pavilion/status_file.py
+++ b/lib/pavilion/status_file.py
@@ -71,6 +71,7 @@ Known States:
         """Validate all of the constants."""
 
         self._help = {}
+        self._fatal_states = {self.STATUS_ERROR}
 
         # Validate the built-in states
         for key in dir(self):
@@ -108,6 +109,11 @@ Known States:
     def list(self):
         """List all the known state names."""
         return self._help.keys()
+
+    def is_fatal(self, state) -> bool:
+        """Determine whether the given state is fatal."""
+
+        return state in self._fatal_states
 
 
 class TestStatesStruct(StatesStruct):
@@ -156,6 +162,15 @@ class TestStatesStruct(StatesStruct):
     RESULTS_ERROR = "A result parser raised an error."
     SKIPPED = "The test has been skipped due to an invalid condition."
     COMPLETE = "For when the test is completely complete."
+    
+    def __init__(self):
+        super().__init__()
+
+        self._fatal_states = self._fatal_states.union(
+                                    {self.ABORTED, self.CREATION_ERROR, self.SCHED_CANCELLED,
+                                    self.SCHED_ERROR, self.BUILD_FAILED, self.BUILD_TIMEOUT,
+                                    self.BUILD_ERROR, self.CANCELLED, self.ENV_FAILED,
+                                    self.RUN_TIMEOUT, self.RUN_ERROR, self.RESULTS_ERROR})
 
 
 class SeriesStatesStruct(StatesStruct):
@@ -182,6 +197,13 @@ class SeriesStatesStruct(StatesStruct):
     CANCELED = "Series was canceled by the user."
     ERROR = "General (fatal) error status."
     COMPLETE = "For when the test is completely complete."
+
+    def __init__(self):
+        super().__init__()
+
+        self._fatal_states = self._fatal_states.union(
+                                    {self.CREATION_ERROR, self.BUILD_ERROR, self.KICKOFF_ERROR,
+                                    self.ERROR})
 
 
 # There is one predefined, global status object defined at module load time.

--- a/lib/pavilion/status_file.py
+++ b/lib/pavilion/status_file.py
@@ -162,7 +162,7 @@ class TestStatesStruct(StatesStruct):
     RESULTS_ERROR = "A result parser raised an error."
     SKIPPED = "The test has been skipped due to an invalid condition."
     COMPLETE = "For when the test is completely complete."
-    
+
     def __init__(self):
         super().__init__()
 


### PR DESCRIPTION
Previously, tests were failing during the build phase and correctly logging a `BUILD_ERROR` state, but then incorrectly continuing on to log a `BUILD_COMPLETE` state, sometimes multiple times. This commit fixes that. It also fixes a double logging of an ABORTED state (albeit with different messages).

Several issues with logging states remain:

- In the aforementioned double ABORTED state, one log statement should probably be removed.

- Nearly identical tests will show either an ENV_FAILED state, or an ENV_FAILED state followed by a BUILD_FAILED state. This inconsistency needs to be resolved, but a decision needs to be made as to the intended behavior.

- Some log states appear to be used inappropriately, which should eventually be fixed.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
