### PR TITLE
Fix deprecation warning box in docs

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,8 @@
+.admonition.warning {
+    background-color: #fff8dc; /* Match warning background */
+    border: 1px solid #f0ad4e;
+}
+
+.admonition.warning > .admonition-title {
+    color: #8a6d3b;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,5 +170,5 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-
-
+def setup(app):
+    app.add_css_file("custom.css")

--- a/docs/tests/index.rst
+++ b/docs/tests/index.rst
@@ -3,9 +3,9 @@
    :caption: Tests Contents:
 
    format.rst
+   suites.rst
    run.rst
    build.rst
-   suites.rst
    env.rst
    permutations.rst
    values.rst

--- a/docs/tests/suites.rst
+++ b/docs/tests/suites.rst
@@ -41,7 +41,9 @@ the previous section. Note the difference in file name between the two organizat
 first, the name of the file is the name of the suite; in the second, the file name is the generic
 `suite.yaml`, and Pavilion derives the suite name from its containing directory.
 
-.. warning:: Deprecation Warning
+.. admonition:: Deprecation Warning
+    :class: warning
+
     Pavilion 2.4 uses the `tests` and `test_src` subdirectories to store suite configs and test
     source code respectively. As of the latest release, these directories are deprecated in favor
     of the single `suites` directory, and support for them will eventually be removed.


### PR DESCRIPTION
Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
