### PR TITLE
Correct `chunk_ids` variable in chunking example

### DIFF
--- a/docs/tests/scheduling.rst
+++ b/docs/tests/scheduling.rst
@@ -317,10 +317,10 @@ of the chunk of which it is a member.
     # full coverage of the system.
     mytest:
       # Creates separate instance of the test for each chunk.
-      permute_on: chunk_ids
+      permute_on: sched.chunk_ids
 
       # Each test instance stores the ID of the chunk it belongs to
-      chunk: '{{chunk_ids}}'
+      chunk: '{{sched.chunk_ids}}'
       schedule:
         # When using chunking, 'all' refers to all nodes in the chunk
         # rather than on the whole system.


### PR DESCRIPTION
Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
