### PR TITLE
Add `--format` argument for `pav show`, including JSON output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ __pycache__/
 # Coverage Artifacts
 .coverage
 
+# Superpowers Specs
+docs/superpowers
+
 pav.pstats
 .local/
 examples/working_dir

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -2,6 +2,10 @@
 # denoting releases. It is entirely independent of the the Pavilion's VERSION.
 RELEASE=2.6
 
+## 2.7 Pre-Release Notes
+  - Added a `--format` flag to `pav show`, which allows presentation of output as a list, table,
+    or JSON.
+
 ## 2.6 Release Notes
 
 - Test run directories are now named based on the series-relative IDs of test runs (e.g. `s1.1`).

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -853,18 +853,18 @@ class ShowCommand(Command):
         """Show all the result parsers."""
 
         if args.doc:
-            try:
-                res_plugin = result_parsers.get_plugin(args.doc)
-            except errors.ResultError:
-                output.fprint(sys.stdout, "Invalid result parser '{}'.".format(args.doc),
+            res_plugin = result_parsers.get_plugin(args.doc)
+
+            if res_plugin is None:
+                output.fprint(self.errfile, "Invalid result parser '{}'.".format(args.doc),
                               color=output.RED)
                 return errno.EINVAL
 
             output.fprint(self.outfile, res_plugin.doc())
 
         else:
-
             rps = []
+
             for rp_name in result_parsers.list_plugins():
                 res_plugin = result_parsers.get_plugin(rp_name)
                 desc = " ".join(str(res_plugin.__doc__).split())
@@ -895,10 +895,10 @@ class ShowCommand(Command):
         if args.vars is not None:
             sched_name = args.vars if args.vars is not None else args.config
 
-            try:
-                sched = schedulers.get_plugin(sched_name)
-            except errors.SchedulerPluginError:
-                output.fprint(sys.stdout, "Invalid scheduler plugin '{}'.".format(sched_name),
+            sched = schedulers.get_plugin(sched_name)
+
+            if sched is None:
+                output.fprint(self.errfile, "Invalid scheduler plugin '{}'.".format(sched_name),
                               color=output.RED)
                 return errno.EINVAL
 
@@ -1063,8 +1063,7 @@ class ShowCommand(Command):
     def _tests_cmd(self, pav_cfg, args):
 
         if args.test_name is not None:
-            self._test_docs_subcmd(pav_cfg, args)
-            return
+            return self._test_docs_subcmd(pav_cfg, args)
 
         resolv = resolver.TestConfigResolver(pav_cfg)
         suites = resolv.find_all_tests()
@@ -1100,6 +1099,12 @@ class ShowCommand(Command):
                     'err':     'None'
                 })
 
+        if len(rows) == 0:
+            output.fprint(self.errfile, f"No tests found matching name {suite_name}.",
+                          color=output.RED)
+
+            return 1
+
         fields = ['name', 'summary']
         if args.verbose or args.err:
             fields.append('path')
@@ -1113,6 +1118,8 @@ class ShowCommand(Command):
             format=args.format,
             title="Available Tests"
         )
+
+        return 0
 
     @sub_cmd('series')
     def _series_cmd(self, pav_cfg, args):
@@ -1167,24 +1174,24 @@ class ShowCommand(Command):
 
         parts = args.test_name.split('.')
         if len(parts) != 2:
-            output.fprint(self.outfile, "You must give a test name as '<suite>.<test>'.",
+            output.fprint(self.errfile, "You must give a test name as '<suite>.<test>'.",
                           color=output.RED)
-            return
+            return 1
 
         suite_name, test_name = parts
 
         if suite_name not in suites:
-            output.fprint(self.outfile, "No such suite: '{}'.\n"
+            output.fprint(self.errfile, "No such suite: '{}'.\n"
                                         "Available test suites:\n{}"
                           .format(suite_name, "\n".join(sorted(suites.keys()))), color=output.RED)
-            return
+            return 1
         tests = suites[suite_name]['tests']
         if test_name not in tests:
-            output.fprint(sys.stdout, "No such test '{}' in suite '{}'.\n"
+            output.fprint(self.errfile, "No such test '{}' in suite '{}'.\n"
                                       "Available tests in suite:\n{}"
                           .format(test_name, suite_name,
                                   "\n".join(sorted(tests.keys()))))
-            return
+            return 1
 
         test = tests[test_name]
 
@@ -1200,6 +1207,7 @@ class ShowCommand(Command):
         pvalue("Summary:", test['summary'])
         pvalue("Documentation:", '\n\n', test['doc'], '\n')
 
+        return 0
 
     DOC_KEYS = ['summary', 'doc']
     PERMUTATION_KEYS = ['permute_on', 'subtitle']

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -213,7 +213,7 @@ class ShowCommand(Command):
 
         module_wrappers = subparsers.add_parser(
             'module_wrappers',
-            aliases=['mod', 'module', 'modules', 'wrappers'],
+            aliases=['module_wrapper', 'mod', 'module', 'modules', 'wrappers', 'wrapper'],
             help="Show the installed module wrappers.",
             description="""Module wrappers allow you to customize how
             pavilion loads modules. They can be used in conjunction with
@@ -231,6 +231,7 @@ class ShowCommand(Command):
 
         nodes_parser = subparsers.add_parser(
             'nodes',
+            aliases=['node'],
             help="Show node status for the current machine, from Pavilion's perspective.",
             description="Display a table of information on the current state of "
                         "system nodes for a given scheduler."
@@ -254,7 +255,7 @@ class ShowCommand(Command):
 
         pav_vars = subparsers.add_parser(
             'pavilion_variables',
-            aliases=['pav_vars', 'pav_var', 'pav'],
+            aliases=['pavilion_variable', 'pav_vars', 'pav_var', 'pav'],
             help="Show the available pavilion variables.",
             description="""Pavilion variables are available for use in test
             configurations. Simply put the name of the variable in curly
@@ -266,7 +267,7 @@ class ShowCommand(Command):
 
         result_parsers = subparsers.add_parser(
             "result_parsers",
-            aliases=['parsers', 'result'],
+            aliases=['result_parser', 'parsers', 'parser', 'result'],
             help="Show result_parser plugin info.",
             description="""Pavilion provides result parsers to allow tests
             parse results out of a variety of formats. These can add keys to
@@ -364,7 +365,7 @@ class ShowCommand(Command):
 
         sys_vars_cmd = subparsers.add_parser(
             'system_variables',
-            aliases=['sys_vars', 'sys', 'sys_var'],
+            aliases=['system_variable', 'sys_vars', 'sys', 'sys_var'],
             help="Show the available system variables.",
             description="System variables are available for use in test "
                         "configurations. Simply put the name in curly "
@@ -713,7 +714,7 @@ class ShowCommand(Command):
                                     verbose=args.verbose,
                                     errors=args.err)
 
-    @sub_cmd('mod', 'module', 'modules', 'wrappers')
+    @sub_cmd('module_wrapper', 'mod', 'module', 'modules', 'wrappers', 'wrapper')
     def _module_wrappers_cmd(self, _, args):
         """List the various module wrapper plugins."""
 
@@ -739,7 +740,7 @@ class ShowCommand(Command):
             title="Available Module Wrapper Plugins"
         )
 
-    @sub_cmd()
+    @sub_cmd('node')
     def _nodes_cmd(self, pav_cfg, args):
         """Lists the nodes as seen by a given scheduler."""
         # pylint: disable=protected-access
@@ -804,7 +805,7 @@ class ShowCommand(Command):
             }
         )
 
-    @sub_cmd('pav_vars', 'pav_var', 'pav')
+    @sub_cmd('pavilion_variable', 'pav_vars', 'pav_var', 'pav')
     def _pavilion_variables_cmd(self, pav_cfg, args):
 
         rows = []
@@ -839,7 +840,7 @@ class ShowCommand(Command):
             title=None
         )
 
-    @sub_cmd('parsers', 'result')
+    @sub_cmd('result_parser', 'parsers', 'parser', 'result')
     def _result_parsers_cmd(self, _, args):
         """Show all the result parsers."""
 
@@ -963,7 +964,7 @@ class ShowCommand(Command):
             title="Pavilion Test States"
         )
 
-    @sub_cmd("sys_var", "sys", "sys_vars")
+    @sub_cmd("system_variable", "sys_var", "sys", "sys_vars")
     def _system_variables_cmd(self, _, args):
 
         rows = []

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -506,6 +506,13 @@ class ShowCommand(Command):
         if args.detail:
             func = expression_functions.get_plugin(args.detail)
 
+            if func is None:
+                output.fprint(self.errfile,
+                f"No function plugin found with name {args.detail}.",
+                color=output.YELLOW)
+
+                return 1
+
             output.fprint(self.outfile, func.signature, color=output.CYAN)
             output.fprint(self.outfile, '-' * len(func.signature))
             output.fprint(self.outfile, func.long_description)

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -122,7 +122,7 @@ class ShowCommand(Command):
         )
 
         platform_parser = subparsers.add_parser(
-            'platform',
+            'platforms',
             help="Show available platform configs.",
             description="Pavilion can support different default configs "
                         "depending on the platform."

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -123,6 +123,7 @@ class ShowCommand(Command):
 
         platform_parser = subparsers.add_parser(
             'platforms',
+            aliases=["platform"],
             help="Show available platform configs.",
             description="Pavilion can support different default configs "
                         "depending on the platform."
@@ -535,7 +536,7 @@ class ShowCommand(Command):
                 title="Available Expression Functions"
             )
 
-    def show_vars(self, pav_cfg, cfg, conf_type, args):
+    def show_vars(self, pav_cfg, cfg, conf_type, args) -> int:
         """Show the variables of a config, each variable is displayed as a
         table."""
 
@@ -665,8 +666,10 @@ class ShowCommand(Command):
 
         if config_data is not None:
             output.fprint(self.outfile, pprint.pformat(config_data, compact=False))
+
+            return 0
         else:
-            output.fprint(sys.stdout, "No {} config found for "
+            output.fprint(self.errfile, "No {} config found for "
                                       "{}.".format(conf_type.strip('s'), cfg_name))
             return errno.EINVAL
 
@@ -688,13 +691,14 @@ class ShowCommand(Command):
         """List all known host files."""
 
         if args.vars:
-            self.show_vars(pav_cfg, args, args.vars, 'hosts')
+            ret = self.show_vars(pav_cfg, args, args.vars, 'hosts')
         elif args.config:
-            self.show_full_config(pav_cfg, args.config, 'hosts')
+            ret = self.show_full_config(pav_cfg, args.config, 'hosts')
         else:
-            self.show_configs_table(pav_cfg, args, 'hosts',
+            ret = self.show_configs_table(pav_cfg, args, 'hosts',
                                     verbose=args.verbose,
                                     errors=args.err)
+        return ret
 
     @sub_cmd('mode')
     def _modes_cmd(self, pav_cfg, args):
@@ -874,7 +878,7 @@ class ShowCommand(Command):
             )
 
     @sub_cmd("sched", "scheduler")
-    def _scheduler_cmd(self, _, args):
+    def _schedulers_cmd(self, _, args):
         """
         :param argparse.Namespace args:
         """

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -105,43 +105,46 @@ class ShowCommand(Command):
             help="List collections found in config dirs."
         )
 
-        func_group = subparsers.add_parser(
+        funcs = subparsers.add_parser(
             'functions',
             aliases=['func', 'function'],
             help="Show available expression functions plugins.",
             description="Expression function plugins allow you to dynamically "
                         "add complex (or simple) new functionality to "
                         "Pavilion value expressions.")
+
+        func_group = funcs.add_mutually_exclusive_group()
+
         func_group.add_argument(
             '--detail',
             action='store',
             help="Show full documentation on the requested plugin."
         )
 
-        os_parser = subparsers.add_parser(
+        platform_parser = subparsers.add_parser(
             'platform',
             help="Show available platform configs.",
             description="Pavilion can support different default configs "
                         "depending on the platform."
         )
 
-        os_group = os_parser.add_mutually_exclusive_group()
-        os_group.add_argument(
-            '--config', action='store', type=str, metavar='<os>',
-            help="Show full os config for desired operating system."
+        platform_group = platform_parser.add_mutually_exclusive_group()
+        platform_group.add_argument(
+            '--config', action='store', type=str, metavar='<platform>',
+            help="Show full platform config for desired operating system."
         )
 
-        os_group.add_argument(
+        platform_group.add_argument(
             '--err', action='store_true', default=False,
-            help="Display any errors encountered while reading a operating system file."
+            help="Display any errors encountered while reading a platform file."
         )
 
-        os_group.add_argument(
-            '--vars', action='store', type=str, metavar='<os>',
-            help="Show defined variables for desired operating system config."
+        platform_group.add_argument(
+            '--vars', action='store', type=str, metavar='<platform>',
+            help="Show defined variables for desired platform config."
         )
 
-        os_group.add_argument(
+        platform_group.add_argument(
             '--verbose', '-v',
             action='store_true', default=False,
             help="Display paths to the operating system files."
@@ -440,7 +443,7 @@ class ShowCommand(Command):
                         "configs, except without the test name.")
 
         # Add --format argument only to those subparsers to which it makes sense as an argument
-        for sp in (cfg_dirs_group, collections_group, func_group, os_parser, hosts, modes,
+        for sp in (cfg_dirs_group, collections_group, func_group, platform_parser, hosts, modes,
                    module_wrappers, nodes_parser, pav_vars, result_parsers, result_base, sched,
                    series, states, sys_vars_cmd, suites, tests):
             try:

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -442,7 +442,7 @@ class ShowCommand(Command):
                         "file. The same format applies to host and mode "
                         "configs, except without the test name.")
 
-        # Add --format argument only to those subparsers to which it makes sense as an argument
+        # Add --format argument only to those subparsers for which it makes sense as an argument
         for subp in (cfg_dirs_group, collections_group, func_group, platform_parser, hosts, modes,
                    module_wrappers, nodes_parser, pav_vars, result_parsers, result_base, sched,
                    series, states, sys_vars_cmd, suites, tests):
@@ -450,7 +450,10 @@ class ShowCommand(Command):
                 '--format',
                 choices=['table', 'list', 'json'],
                 default='table',
-                help='Output format (default: table).'
+                help='Specify an output format for this subcommand. Options are:'
+                     '  table (default) - output a table'
+                     '  list - output as a simple list, with no header, suitable for scripting'
+                     '  json - output as JSON'
             )
 
     def run(self, pav_cfg, args):

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -537,7 +537,7 @@ class ShowCommand(Command):
                 title="Available Expression Functions"
             )
 
-    def show_vars(self, pav_cfg, cfg, conf_type, args) -> int:
+    def show_vars(self, pav_cfg, args, cfg, conf_type) -> int:
         """Show the variables of a config, each variable is displayed as a
         table."""
 
@@ -679,7 +679,7 @@ class ShowCommand(Command):
         """List all known platform files."""
 
         if args.vars:
-            self.show_vars(pav_cfg, args.vars, 'platforms', args=args)
+            self.show_vars(pav_cfg, args, args.vars, 'platforms')
         elif args.config:
             self.show_full_config(pav_cfg, args.config, 'platforms')
         else:

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -446,16 +446,12 @@ class ShowCommand(Command):
         for sp in (cfg_dirs_group, collections_group, func_group, platform_parser, hosts, modes,
                    module_wrappers, nodes_parser, pav_vars, result_parsers, result_base, sched,
                    series, states, sys_vars_cmd, suites, tests):
-            try:
-                sp.add_argument(
-                    '--format',
-                    choices=['table', 'list', 'json'],
-                    default='table',
-                    help='Output format (default: table).'
-                )
-            except:
-                print(f"Error adding --format argument to subparser {sp}")
-                raise
+            sp.add_argument(
+                '--format',
+                choices=['table', 'list', 'json'],
+                default='table',
+                help='Output format (default: table).'
+            )
 
     def run(self, pav_cfg, args):
         """Run the show command's chosen sub-command."""

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -431,7 +431,10 @@ class ShowCommand(Command):
             action='store_true', default=False,
             help='Display any errors encountered while reading the test.'
         )
-        tests.add_argument(
+
+        tests_group = tests.add_mutually_exclusive_group()
+
+        tests_group.add_argument(
             '--doc', action='store', type=str, dest='test_name',
             help="Show test documentation string."
         )
@@ -447,7 +450,7 @@ class ShowCommand(Command):
         # Add --format argument only to those subparsers for which it makes sense as an argument
         for subp in (cfg_dirs_group, collections_group, func_group, platform_parser, hosts, modes,
                    module_wrappers, nodes_parser, pav_vars, result_parsers, result_base, sched,
-                   series, states, sys_vars_cmd, suites, tests):
+                   series, states, sys_vars_cmd, suites, tests_group):
             subp.add_argument(
                 '--format',
                 choices=['table', 'list', 'json'],

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -549,6 +549,7 @@ class ShowCommand(Command):
                 self.errfile,
                 f"Could not find a config for {conf_type} '{cfg}'",
                 color=output.YELLOW)
+
             return 1
 
         with file.open() as config_file:
@@ -620,6 +621,8 @@ class ShowCommand(Command):
                                                            compact=True))
             output.fprint(self.outfile, "\n")
 
+        return 0
+
     def show_configs_table(self, pav_cfg, args, conf_type, errors=False,
                            verbose=False):
         """Default config table, shows the config name and if it can be
@@ -653,6 +656,8 @@ class ShowCommand(Command):
             title=None
         )
 
+        return 0
+
     def show_full_config(self, pav_cfg, cfg_name, conf_type):
         """Show the full config of a given os/host/mode."""
 
@@ -679,13 +684,15 @@ class ShowCommand(Command):
         """List all known platform files."""
 
         if args.vars:
-            self.show_vars(pav_cfg, args, args.vars, 'platforms')
+            ret = self.show_vars(pav_cfg, args, args.vars, 'platforms')
         elif args.config:
-            self.show_full_config(pav_cfg, args.config, 'platforms')
+            ret = self.show_full_config(pav_cfg, args.config, 'platforms')
         else:
-            self.show_configs_table(pav_cfg, args, 'platforms',
+            ret = self.show_configs_table(pav_cfg, args, 'platforms',
                                     verbose=args.verbose,
                                     errors=args.err)
+
+        return ret
 
     @sub_cmd('host')
     def _hosts_cmd(self, pav_cfg, args):
@@ -706,13 +713,14 @@ class ShowCommand(Command):
         """List all known mode files."""
 
         if args.vars:
-            self.show_vars(pav_cfg, args, args.vars, 'modes')
+            ret = self.show_vars(pav_cfg, args, args.vars, 'modes')
         elif args.config:
-            self.show_full_config(pav_cfg, args.config, 'modes')
+            ret = self.show_full_config(pav_cfg, args.config, 'modes')
         else:
-            self.show_configs_table(pav_cfg, args, 'modes',
+            ret = self.show_configs_table(pav_cfg, args, 'modes',
                                     verbose=args.verbose,
                                     errors=args.err)
+        return ret
 
     @sub_cmd('module_wrapper', 'mod', 'module', 'modules', 'wrappers', 'wrapper')
     def _module_wrappers_cmd(self, _, args):

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -8,7 +8,7 @@ import os
 import pprint
 import sys
 from pathlib import Path
-from typing import Union
+from typing import Union, Dict, List, Optional
 
 import yaml_config
 from pavilion import config
@@ -45,6 +45,25 @@ class ShowCommand(Command):
 
         self._parser = None  # type: Union[argparse.ArgumentParser,None]
 
+    def _format_rows(self, rows: List, fields: List[str], format: str, title: str = "",
+                     field_info: Optional[Dict] = None) -> None:
+        """Format rows according to the selected format."""
+
+        if format == 'json':
+            output.json_dump(rows, self.outfile)
+        elif format == 'list':
+            for row in rows:
+                line = '\t'.join(str(row.get(f, '')) for f in fields)
+                self.outfile.write(line + '\n')
+        else:
+            output.draw_table(
+                self.outfile,
+                fields=fields,
+                rows=rows,
+                title=title,
+                field_info=field_info,
+            )
+
     def _setup_arguments(self, parser):
 
         subparsers = parser.add_subparsers(
@@ -70,7 +89,7 @@ class ShowCommand(Command):
                  "current config."
         )
 
-        subparsers.add_parser(
+        cfg_dirs_group = subparsers.add_parser(
             'config_dirs',
             aliases=['config_dir'],
             help="List the config dirs.",
@@ -80,7 +99,7 @@ class ShowCommand(Command):
             defined priorities."""
         )
 
-        subparsers.add_parser(
+        collections_group = subparsers.add_parser(
             'collections',
             aliases=['collection'],
             help="List collections found in config dirs."
@@ -229,7 +248,7 @@ class ShowCommand(Command):
             '--show-filtered', action='store_true', default=False,
             help="Show the filtered nodes along with their reason for being filtered.")
 
-        subparsers.add_parser(
+        pav_vars = subparsers.add_parser(
             'pavilion_variables',
             aliases=['pav_vars', 'pav_var', 'pav'],
             help="Show the available pavilion variables.",
@@ -268,7 +287,7 @@ class ShowCommand(Command):
             help='Display the path to the plugin file.'
         )
 
-        subparsers.add_parser(
+        result_base = subparsers.add_parser(
             "result_base",
             help="Show base result keys.",
         )
@@ -328,7 +347,7 @@ class ShowCommand(Command):
             help='Show any superseded series files.'
         )
 
-        subparsers.add_parser(
+        states = subparsers.add_parser(
             'states',
             aliases=['state'],
             help="Show the pavilion test states and their meaning.",
@@ -420,6 +439,21 @@ class ShowCommand(Command):
                         "file. The same format applies to host and mode "
                         "configs, except without the test name.")
 
+        # Add --format argument only to those subparsers to which it makes sense as an argument
+        for sp in (cfg_dirs_group, collections_group, func_group, os_parser, hosts, modes,
+                   module_wrappers, nodes_parser, pav_vars, result_parsers, result_base, sched,
+                   series, states, sys_vars_cmd, suites, tests):
+            try:
+                sp.add_argument(
+                    '--format',
+                    choices=['table', 'list', 'json'],
+                    default='table',
+                    help='Output format (default: table).'
+                )
+            except:
+                print(f"Error adding --format argument to subparser {sp}")
+                raise
+
     def run(self, pav_cfg, args):
         """Run the show command's chosen sub-command."""
 
@@ -436,18 +470,18 @@ class ShowCommand(Command):
                                                values=pav_cfg)
 
     @sub_cmd('config_dir')
-    def _config_dirs_cmd(self, pav_cfg, _):
+    def _config_dirs_cmd(self, pav_cfg, args):
         """List the configuration directories."""
 
-        output.draw_table(
-            self.outfile,
+        self._format_rows(
+            rows=list(pav_cfg.configs.values()),
             fields=['label', 'path', 'working_dir'],
-            rows=pav_cfg.configs.values(),
+            format=args.format,
             title="Config directories by priority."
         )
 
     @sub_cmd('collection')
-    def _collections_cmd(self, pav_cfg, _):
+    def _collections_cmd(self, pav_cfg, args):
         """List all files found in the collections directories in all config directories."""
 
         collections = []
@@ -459,8 +493,12 @@ class ShowCommand(Command):
                     collections.append({'collection': col_file,
                                         'path': Path(collection_dir / col_file)})
 
-        output.draw_table(self.outfile, fields=['collection', 'path'], rows=collections,
-                          title="Available collections and paths.")
+        self._format_rows(
+            rows=collections,
+            fields=['collection', 'path'],
+            format=args.format,
+            title="Available collections and paths."
+        )
 
     @sub_cmd('function', 'func')
     def _functions_cmd(self, _, args):
@@ -481,14 +519,14 @@ class ShowCommand(Command):
                     'name':        func.name,
                     'signature':   func.signature,
                     'description': func.description})
-            output.draw_table(
-                self.outfile,
-                fields=['name', 'signature', 'description'],
+            self._format_rows(
                 rows=rows,
+                fields=['name', 'signature', 'description'],
+                format=args.format,
                 title="Available Expression Functions"
             )
 
-    def show_vars(self, pav_cfg, cfg, conf_type):
+    def show_vars(self, pav_cfg, cfg, conf_type, args):
         """Show the variables of a config, each variable is displayed as a
         table."""
 
@@ -517,12 +555,12 @@ class ShowCommand(Command):
             else:
                 complex_vars.append(var_key)
         if simple_vars:
-            output.draw_table(
-                self.outfile,
-                field_info={},
-                fields=['name', 'value'],
+            self._format_rows(
                 rows=simple_vars,
-                title="Simple Variables"
+                fields=['name', 'value'],
+                format=args.format,
+                title="Simple Variables",
+                field_info={}
             )
 
         if complex_vars:
@@ -538,12 +576,12 @@ class ShowCommand(Command):
                         'index': idx,
                         'value': cfg['variables'][var][idx]
                     })
-                output.draw_table(
-                    self.outfile,
-                    field_info={},
-                    fields=['index', 'value'],
+                self._format_rows(
                     rows=simple_vars,
-                    title=var
+                    fields=['index', 'value'],
+                    format=args.format,
+                    title=var,
+                    field_info={}
                 )
             # List of dicts.
             elif len(subvar) < 10:
@@ -556,13 +594,13 @@ class ShowCommand(Command):
                             fields.append(key)
                         dict_data.update({key: val})
                     simple_vars.append(dict_data)
-                output.draw_table(
-                    self.outfile,
-                    field_info={},
-                    fields=fields,
-                    rows=simple_vars,
-                    title=var
-                )
+                self._format_rows(
+                     rows=simple_vars,
+                     fields=fields,
+                     format=args.format,
+                     title=var,
+                     field_info={}
+                 )
             else:
                 output.fprint(self.outfile, var)
                 output.fprint(self.outfile, "(Showing as json due to the insane number of "
@@ -571,7 +609,7 @@ class ShowCommand(Command):
                                                            compact=True))
             output.fprint(self.outfile, "\n")
 
-    def show_configs_table(self, pav_cfg, conf_type, errors=False,
+    def show_configs_table(self, pav_cfg, args, conf_type, errors=False,
                            verbose=False):
         """Default config table, shows the config name and if it can be
         loaded."""
@@ -597,10 +635,11 @@ class ShowCommand(Command):
                 'err': configs[name]['error']
             })
 
-        output.draw_table(
-            self.outfile,
+        self._format_rows(
+            rows=data,
             fields=col_names,
-            rows=data
+            format=args.format,
+            title=None
         )
 
     def show_full_config(self, pav_cfg, cfg_name, conf_type):
@@ -627,11 +666,11 @@ class ShowCommand(Command):
         """List all known platform files."""
 
         if args.vars:
-            self.show_vars(pav_cfg, args.vars, 'platforms')
+            self.show_vars(pav_cfg, args.vars, 'platforms', args=args)
         elif args.config:
             self.show_full_config(pav_cfg, args.config, 'platforms')
         else:
-            self.show_configs_table(pav_cfg, 'platforms',
+            self.show_configs_table(pav_cfg, args, 'platforms',
                                     verbose=args.verbose,
                                     errors=args.err)
 
@@ -640,11 +679,11 @@ class ShowCommand(Command):
         """List all known host files."""
 
         if args.vars:
-            self.show_vars(pav_cfg, args.vars, 'hosts')
+            self.show_vars(pav_cfg, args, args.vars, 'hosts')
         elif args.config:
             self.show_full_config(pav_cfg, args.config, 'hosts')
         else:
-            self.show_configs_table(pav_cfg, 'hosts',
+            self.show_configs_table(pav_cfg, args, 'hosts',
                                     verbose=args.verbose,
                                     errors=args.err)
 
@@ -653,11 +692,11 @@ class ShowCommand(Command):
         """List all known mode files."""
 
         if args.vars:
-            self.show_vars(pav_cfg, args.vars, 'modes')
+            self.show_vars(pav_cfg, args, args.vars, 'modes')
         elif args.config:
             self.show_full_config(pav_cfg, args.config, 'modes')
         else:
-            self.show_configs_table(pav_cfg, 'modes',
+            self.show_configs_table(pav_cfg, args, 'modes',
                                     verbose=args.verbose,
                                     errors=args.err)
 
@@ -680,10 +719,10 @@ class ShowCommand(Command):
         if args.verbose:
             fields.append('path')
 
-        output.draw_table(
-            self.outfile,
+        self._format_rows(
             fields=fields,
             rows=modules,
+            format=args.format,
             title="Available Module Wrapper Plugins"
         )
 
@@ -741,19 +780,19 @@ class ShowCommand(Command):
                 if node not in filtered_nodes:
                     shown_nodes.append(nodes[node])
 
-        output.draw_table(
-            outfile=self.outfile,
-            fields=fields,
-            title="System node state via {}".format(args.scheduler.capitalize()),
+        self._format_rows(
             rows=shown_nodes,
+            fields=fields,
+            format=args.format,
+            title="System node state via {}".format(args.scheduler.capitalize()),
             field_info={
                 'partitions': {'transform': lambda f: ', '.join(sorted(f))},
                 'states': {'transform': lambda f: ', '.join(sorted(f))},
-                },
-            )
+            }
+        )
 
     @sub_cmd('pav_vars', 'pav_var', 'pav')
-    def _pavilion_variables_cmd(self, pav_cfg, _):
+    def _pavilion_variables_cmd(self, pav_cfg, args):
 
         rows = []
 
@@ -764,15 +803,15 @@ class ShowCommand(Command):
                 'description': pav_cfg.pav_vars.info(key)['help'],
             })
 
-        output.draw_table(
-            self.outfile,
-            fields=['name', 'value', 'description'],
+        self._format_rows(
             rows=rows,
+            fields=['name', 'value', 'description'],
+            format=args.format,
             title="Available Pavilion Variables"
         )
 
     @sub_cmd()
-    def _result_base_cmd(self, _, __):
+    def _result_base_cmd(self, _, args):
         """Show base result keys."""
 
         rows = [
@@ -780,10 +819,11 @@ class ShowCommand(Command):
             for key, (_, doc) in result.BASE_RESULTS.items()
         ]
 
-        output.draw_table(
-            self.outfile,
-            ['name', 'doc'],
-            rows
+        self._format_rows(
+            rows=rows,
+            fields=['name', 'doc'],
+            format=args.format,
+            title=None
         )
 
     @sub_cmd('parsers', 'result')
@@ -817,10 +857,10 @@ class ShowCommand(Command):
             if args.verbose:
                 fields.append('path')
 
-            output.draw_table(
-                self.outfile,
-                fields=fields,
+            self._format_rows(
                 rows=rps,
+                fields=fields,
+                format=args.format,
                 title="Available Result Parsers"
             )
 
@@ -850,10 +890,10 @@ class ShowCommand(Command):
             for key in sorted(list(svars.keys())):
                 sched_vars.append(svars.info(key))
 
-            output.draw_table(
-                self.outfile,
-                fields=['name', 'deferred', 'example', 'help'],
+            self._format_rows(
                 rows=sched_vars,
+                fields=['name', 'deferred', 'example', 'help'],
+                format=args.format,
                 title="Variables for the {} scheduler plugin.".format(args.vars)
             )
 
@@ -885,15 +925,15 @@ class ShowCommand(Command):
             if args.verbose:
                 fields.append('path')
 
-            output.draw_table(
-                self.outfile,
-                fields=fields,
+            self._format_rows(
                 rows=scheds,
+                fields=fields,
+                format=args.format,
                 title="Available Scheduler Plugins"
             )
 
     @sub_cmd("state")
-    def _states_cmd(self, *_):
+    def _states_cmd(self, _, args):
         """Show all of the states that a test can be in."""
 
         states = []
@@ -903,10 +943,10 @@ class ShowCommand(Command):
                 'description': status_file.STATES.help(state)
             })
 
-        output.draw_table(
-            self.outfile,
-            fields=['name', 'description'],
+        self._format_rows(
             rows=states,
+            fields=['name', 'description'],
+            format=args.format,
             title="Pavilion Test States"
         )
 
@@ -940,10 +980,10 @@ class ShowCommand(Command):
         if args.verbose:
             fields.append('path')
 
-        output.draw_table(
-            self.outfile,
-            fields=fields,
+        self._format_rows(
             rows=rows,
+            fields=fields,
+            format=args.format,
             title="Available System Variables"
         )
 
@@ -988,10 +1028,10 @@ class ShowCommand(Command):
             if args.err:
                 fields.append('err')
 
-        output.draw_table(
-            self.outfile,
-            fields=fields,
+        self._format_rows(
             rows=rows,
+            fields=fields,
+            format=args.format,
             title="Available Test Suites"
         )
 
@@ -1045,10 +1085,10 @@ class ShowCommand(Command):
             if args.err:
                 fields.append('err')
 
-        output.draw_table(
-            self.outfile,
-            fields=fields,
+        self._format_rows(
             rows=rows,
+            fields=fields,
+            format=args.format,
             title="Available Tests"
         )
 
@@ -1086,14 +1126,15 @@ class ShowCommand(Command):
         if args.conflicts:
             fields.append('supersedes')
 
-        output.draw_table(
-            self.outfile,
+        self._format_rows(
+            rows=all_series,
+            fields=fields,
+            format=args.format,
+            title=None,
             field_info={
                 'test_sets': {'transform': '\n'.join},
                 'supersedes': {'transform': '\n'.join},
-            },
-            fields=fields,
-            rows=all_series,
+            }
         )
 
     def _test_docs_subcmd(self, pav_cfg, args):

--- a/lib/pavilion/commands/show.py
+++ b/lib/pavilion/commands/show.py
@@ -443,10 +443,10 @@ class ShowCommand(Command):
                         "configs, except without the test name.")
 
         # Add --format argument only to those subparsers to which it makes sense as an argument
-        for sp in (cfg_dirs_group, collections_group, func_group, platform_parser, hosts, modes,
+        for subp in (cfg_dirs_group, collections_group, func_group, platform_parser, hosts, modes,
                    module_wrappers, nodes_parser, pav_vars, result_parsers, result_base, sched,
                    series, states, sys_vars_cmd, suites, tests):
-            sp.add_argument(
+            subp.add_argument(
                 '--format',
                 choices=['table', 'list', 'json'],
                 default='table',

--- a/lib/pavilion/expression_functions/__init__.py
+++ b/lib/pavilion/expression_functions/__init__.py
@@ -21,7 +21,6 @@ def list_plugins():
 
     return _FUNCTIONS.keys()
 
-
 def register_core_plugins():
     """Find all the core function plugins and activate them."""
 

--- a/lib/pavilion/expression_functions/__init__.py
+++ b/lib/pavilion/expression_functions/__init__.py
@@ -3,19 +3,18 @@ used in Pavilion expressions, both within normal Pavilion strings and
 in result evaluations.
 """
 
+from typing import Optional
+
 from .base import (FunctionPlugin, _FUNCTIONS, num, __reset)
 from .core import CoreFunctionPlugin
 from ..errors import FunctionPluginError
 
 
-def get_plugin(name: str) -> FunctionPlugin:
-    """Get the function plugin called 'name'."""
+def get_plugin(name: str) -> Optional[FunctionPlugin]:
+    """Get the function plugin called 'name'. Returns None if a plugin with the given name
+    does not exist."""
 
-    if name not in _FUNCTIONS:
-        raise FunctionPluginError("No such function '{}'".format(name))
-    else:
-        return _FUNCTIONS[name]
-
+    return _FUNCTIONS.get(name)
 
 def list_plugins():
     """Return the list of function plugin names."""

--- a/lib/pavilion/output.py
+++ b/lib/pavilion/output.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from typing import List, Dict, Union, TextIO, Any, Optional, Callable
 
 from pavilion import errors
-from pavilion.test_ids import TestID, SeriesID, GroupID
+from pavilion.test_ids import ID
 
 BLACK = 30
 RED = 31
@@ -973,7 +973,11 @@ class PavEncoder(json.JSONEncoder):
         # Just auto-convert anything that looks like a dict.
         elif isinstance(o, (dict, UserDict)):
             return dict(o)
-        elif isinstance(o, (TestID, SeriesID, GroupID)):
+        elif isinstance(o, (str, UserString)):
+            return str(o)
+        elif isinstance(o, ID):
+            return str(o)
+        elif isinstance(o, Exception):
             return str(o)
         # or has an 'as_dict' method
         elif hasattr(o, 'as_dict'):

--- a/lib/pavilion/parsers/expressions.py
+++ b/lib/pavilion/parsers/expressions.py
@@ -483,9 +483,9 @@ class BaseExprTransformer(PavTransformer):
         args = [tok.value for tok in items[2:paren_idx]]
         ref_parts = items[paren_idx+1:]
 
-        try:
-            func = functions.get_plugin(func_name)
-        except pavilion.errors.FunctionPluginError:
+        func = functions.get_plugin(func_name)
+
+        if func is None:
             raise ParserValueError(
                 token=items[0],
                 message="No such function '{}'\n"

--- a/lib/pavilion/resolver/proto_test.py
+++ b/lib/pavilion/resolver/proto_test.py
@@ -241,9 +241,10 @@ class RawProtoTest:
         if sched_name is None:
             raise RuntimeError("No scheduler was given. This should only happen "
                                "when unit tests fail to define it.", request=self.request)
-        try:
-            sched = schedulers.get_plugin(sched_name)
-        except SchedulerPluginError:
+
+        sched = schedulers.get_plugin(sched_name)
+
+        if sched is None:
             raise TestConfigError("Could not find scheduler '{}' for test '{}'"
                                   .format(sched_name, test_name), request=self.request)
         if not sched.available():

--- a/lib/pavilion/result_parsers/base_classes.py
+++ b/lib/pavilion/result_parsers/base_classes.py
@@ -34,7 +34,7 @@ def get_plugin(name):
 :rtype: ResultParser
 """
 
-    return _RESULT_PARSERS[name]
+    return _RESULT_PARSERS.get(name)
 
 
 def list_plugins():

--- a/lib/pavilion/schedulers/__init__.py
+++ b/lib/pavilion/schedulers/__init__.py
@@ -32,7 +32,7 @@ SchedulerPlugin.register_core_plugins = register_core_plugins
 
 
 def get_plugin(name) -> Union[SchedulerPluginBasic,
-                              SchedulerPluginAdvanced]:
+                              SchedulerPluginAdvanced, None]:
     """Return a scheduler plugin
 
     :param str name: The name of the scheduler plugin.
@@ -41,11 +41,7 @@ def get_plugin(name) -> Union[SchedulerPluginBasic,
     if _SCHEDULER_PLUGINS is None:
         raise SchedulerPluginError("No scheduler plugins loaded.")
 
-    if name not in _SCHEDULER_PLUGINS:
-        raise SchedulerPluginError(
-            "Scheduler plugin not found: '{}'".format(name))
-
-    return _SCHEDULER_PLUGINS[name]
+    return _SCHEDULER_PLUGINS.get(name)
 
 
 def list_plugins():

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -294,7 +294,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in combinations(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, r=2):
                 cmd = ["show", "platforms"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
@@ -535,7 +535,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in combinations(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, r=2):
                 cmd = ["show", "hosts"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
@@ -776,7 +776,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in combinations(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, r=2):
                 cmd = ["show", "modes"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
@@ -1271,7 +1271,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in combinations(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, r=2):
                 cmd = ["show", "result_parsers"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
@@ -1426,7 +1426,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in combinations(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, r=2):
                 cmd = ["show", "schedulers"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -542,7 +542,7 @@ class ShowTests(unittest.PavTestCase):
         self.assertNotEqual(error, "")
 
     def test_hosts_subcommand_vars_format(self):
-        """Test that the platforms subcommand --vars argument behaves as expected when the
+        """Test that the hosts subcommand --vars argument behaves as expected when the
         --format argument is also passed."""
 
         parser = arguments.get_parser()
@@ -564,14 +564,201 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_modes_subcommand(self):
+        """Test that the modes subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show modes gave empty output")
+
+    def test_modes_subcommand_format_argument(self):
+        """Test that the modes subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show modes --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show modes --format json did not produce valid JSON. Output\n{output}")
+
+    def test_modes_subcommand_config_argument(self):
+        """Test that the modes subcommand works as expected when the --config argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--config", "defaulted"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes --config defaulted terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show modes --config defaulted gave empty output")
+
+    def test_modes_subcommand_config_mutual_exclusion(self):
+        """Test that the modes subcommand does not allow the --config and --format
+        arguments to be passed at the same time.
+
+        Note that this test does not test whether main.py catches the error raised by argparse."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        with self.assertRaises(SystemExit):
+            args = parser.parse_args(("show", "modes", "--format", "json", "--config", "defaulted"))
+
+    def test_modes_subcommand_config_argument_nonexistant(self):
+        """Test that the modes subcommand --config argument does not raise an exception when
+        passed a non-existant platform."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--config", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show modes --config nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show modes --config nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_modes_subcommand_verbose_argument(self):
+        """Test that the modes subcommand --verbose argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show modes --verbose gave empty output")
+
+    def test_modes_subcommand_verbose_format(self):
+        """Test that the modes subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show modes --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_modes_subcommand_vars_argument(self):
+        """Test that the modes subcommand --vars argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--vars", "defaulted"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes --vars defaulted terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show modes --vars defaulted gave empty output")
+
+    def test_modes_subcommand_vars_argument_nonexistant(self):
+        """Test that the modes subcommand --vars argument does not raise an exception when
+        passed a non-existant host."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--vars", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show modes --vars nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show modes --vars nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_modes_subcommand_vars_format(self):
+        """Test that the modes subcommand --vars argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--vars", "defaulted", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes --vars defaulted --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show modes --vars defaulted --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
 
     def test_show_cmds(self):
 
-        arg_lists = []
-            ('show', 'modes'),
-            ('show', 'modes', '--verbose'),
-            ('show', 'modes', '--vars', 'defaulted'),
-            ('show', 'modes', '--config', 'defaulted'),
+        arg_lists = [
             ('show', 'module_wrappers'),
             ('show', 'module_wrappers', '--verbose'),
             ('show', 'pav_vars'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -53,6 +53,22 @@ class ShowTests(unittest.PavTestCase):
         self.assertEqual(output, expected.getvalue(),
                          msg='Loaded Pavilion config was printed instead of the template.')
 
+    def test_config_subcommand_aliases(self):
+        """Test that the aliases for the config subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("config", "conf")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
     def test_config_dirs_subcommand(self):
         """Test that the config_dirs subcommand, with no arguments, works as expected."""
 
@@ -92,6 +108,23 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_config_dirs_subcommand_aliases(self):
+        """Test that the aliases for the config_dirs subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("config_dirs", "config_dir")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
+
     def test_collections_subcommand(self):
         """Test that the collections subcommand, with no arguments, works as expected."""
 
@@ -130,6 +163,23 @@ class ShowTests(unittest.PavTestCase):
             self.fail(f"pav show collections --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_collections_subcommand_aliases(self):
+        """Test that the aliases for the collections subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("collections", "collection")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
 
     def test_functions_subcommand(self):
         """Test that the functions subcommand, with no arguments, works as expected."""
@@ -223,6 +273,22 @@ class ShowTests(unittest.PavTestCase):
 
         with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: ('--format json', '--detail int')"):
             args = parser.parse_args(cmd)
+
+    def test_functions_subcommand_aliases(self):
+        """Test that the aliases for the functions subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("functions", "functions", "func")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
 
     def test_platforms_subcommand(self):
         """Test that the platforms subcommand, with no arguments, works as expected."""
@@ -465,6 +531,22 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_platforms_subcommand_aliases(self):
+        """Test that the aliases for the platforms subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("platforms", "platform")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
     def test_hosts_subcommand(self):
         """Test that the hosts subcommand, with no arguments, works as expected."""
 
@@ -705,6 +787,22 @@ class ShowTests(unittest.PavTestCase):
             self.fail(f"pav show hosts --err --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_hosts_subcommand_aliases(self):
+        """Test that the aliases for the hosts subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("hosts", "host")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
 
     def test_modes_subcommand(self):
         """Test that the modes subcommand, with no arguments, works as expected."""
@@ -947,6 +1045,22 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_modes_subcommand_aliases(self):
+        """Test that the aliases for the modes subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("modes", "mode")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
     def test_module_wrappers_subcommand(self):
         """Test that the module_wrappers subcommand, with no arguments, works as expected."""
 
@@ -1024,6 +1138,22 @@ class ShowTests(unittest.PavTestCase):
             self.fail(f"pav show module_wrappers --verbose --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_module_wrappers_subcommand_aliases(self):
+        """Test that the aliases for the module_wrappers subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("module_wrappers", "module_wrapper", "mod", "modules", "module", "wrappers", "wrapper")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
 
     def test_nodes_subcommand(self):
         """Test that the nodes subcommand, with no arguments, works as expected."""
@@ -1103,42 +1233,74 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
-    def test_pav_vars_subcommand(self):
-        """Test that the pav_vars subcommand, with no arguments, works as expected."""
+    def test_nodes_subcommand_aliases(self):
+        """Test that the aliases for the nodes subcommand work correctly."""
 
         parser = arguments.get_parser()
 
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "pav_vars"))
+        aliases = ("nodes", "node")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
+    def test_pavilion_variables_subcommand(self):
+        """Test that the pavilion_variables subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "pavilion_variables"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show pav_vars terminated with non-zero error code.')
+                         msg='pav show pavilion_variables terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
-        self.assertNotEqual(output, "", "pav show pav_vars gave empty output")
+        self.assertNotEqual(output, "", "pav show pavilion_variables gave empty output")
 
-    def test_pav_vars_subcommand_format_argument(self):
-        """Test that the pav_vars subcommand --format argument behaves as expected."""
+    def test_pavilion_variables_subcommand_format_argument(self):
+        """Test that the pavilion_variables subcommand --format argument behaves as expected."""
 
         parser = arguments.get_parser()
 
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "pav_vars", "--format", "json"))
+        args = parser.parse_args(("show", "pavilion_variables", "--format", "json"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show pav_vars --format json terminated with non-zero error code.')
+                         msg='pav show pavilion_variables --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"pav show nodes --format json did not produce valid JSON. Output\n{output}")
+            self.fail(f"pav show pavilion_variables --format json did not produce valid JSON. Output\n{output}")
+
+    def test_pavilion_variables_subcommand_aliases(self):
+        """Test that the aliases for the pavilion_variables subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("pavilion_variables", "pavilion_variable", "pav_vars", "pav_vars", "pav")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
 
     def test_result_parsers_subcommand(self):
         """Test that the result_parsers subcommand, with no arguments, works as expected."""
@@ -1318,6 +1480,22 @@ class ShowTests(unittest.PavTestCase):
             self.fail(f"pav show result_parsers --verbose --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_result_parsers_subcommand_aliases(self):
+        """Test that the aliases for the result_parsers subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("result_parsers", "result_parser", "parsers", "parser", "result")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
 
     def test_result_base_subcommand(self):
         """Test that the result_base subcommand, with no arguments, works as expected."""
@@ -1576,6 +1754,22 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_schedulers_subcommand_aliases(self):
+        """Test that the aliases for the schedulers subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("schedulers", "scheduler", "sched")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
     def test_series_subcommand(self):
         """Test that the series subcommand, with no arguments, works as expected."""
 
@@ -1813,6 +2007,22 @@ class ShowTests(unittest.PavTestCase):
         except Exception as e:
             self.fail(f"pav show states --format json did not produce valid JSON. Output\n{output}")
 
+    def test_states_subcommand_aliases(self):
+        """Test that the aliases for the states subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("states", "state")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
     def test_suites_subcommand(self):
         """Test that the suites subcommand, with no arguments, works as expected."""
 
@@ -1972,6 +2182,22 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_suites_subcommand_aliases(self):
+        """Test that the aliases for the suites subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("suites", "suite")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
+
     def test_system_variables_subcommand(self):
         """Test that the system_variables subcommand, with no arguments, works as expected."""
 
@@ -2049,6 +2275,22 @@ class ShowTests(unittest.PavTestCase):
             self.fail(f"pav show system_variables --verbose --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_system_variables_subcommand_aliases(self):
+        """Test that the aliases for the system_variables subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("system_variables", "system_variable", "sys_vars", "sys_var", "sys")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
 
     def test_test_config_subcommand(self):
         """Test that the test_config subcommand, with no arguments, works as expected."""
@@ -2280,6 +2522,22 @@ class ShowTests(unittest.PavTestCase):
 
         with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: ('--format json', '--doc hello_world.narf')"):
             args = parser.parse_args(cmd)
+
+    def test_tests_subcommand_aliases(self):
+        """Test that the aliases for the tests subcommand work correctly."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        aliases = ("tests", "test")
+
+        for alias in aliases:
+            args = parser.parse_args(("show", alias))
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg=f"Alias pav show {alias} was not recognized.")
 
     FORMATTABLE_SUBCMDS = ('config_dirs', 'collections', 'functions', 'platform', 'hosts', 'modes',
                         'module_wrappers', 'pav_vars', 'result_parsers', 'result_base',

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -373,13 +373,201 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_hosts_subcommand(self):
+        """Test that the hosts subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show hosts gave empty output")
+
+    def test_hosts_subcommand_format_argument(self):
+        """Test that the hosts subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show hosts --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show hosts --format json did not produce valid JSON. Output\n{output}")
+
+    def test_hosts_subcommand_config_argument(self):
+        """Test that the hosts subcommand works as expected when the --config argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--config", "this"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts --config this terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show hosts --config this gave empty output")
+
+    def test_hosts_subcommand_config_mutual_exclusion(self):
+        """Test that the hosts subcommand does not allow the --config and --format
+        arguments to be passed at the same time.
+
+        Note that this test does not test whether main.py catches the error raised by argparse."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        with self.assertRaises(SystemExit):
+            args = parser.parse_args(("show", "hosts", "--format", "json", "--config", "this"))
+
+    def test_hosts_subcommand_config_argument_nonexistant(self):
+        """Test that the hosts subcommand --config argument does not raise an exception when
+        passed a non-existant platform."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--config", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show hosts --config nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show hosts --config nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_hosts_subcommand_verbose_argument(self):
+        """Test that the hosts subcommand --verbose argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show hosts --verbose gave empty output")
+
+    def test_hosts_subcommand_verbose_format(self):
+        """Test that the hosts subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show hosts --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_hosts_subcommand_vars_argument(self):
+        """Test that the hosts subcommand --vars argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--vars", "this"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts --vars this terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show hosts --vars this gave empty output")
+
+    def test_hosts_subcommand_vars_argument_nonexistant(self):
+        """Test that the hosts subcommand --vars argument does not raise an exception when
+        passed a non-existant host."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--vars", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show hosts --vars nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show hosts --vars nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_hosts_subcommand_vars_format(self):
+        """Test that the platforms subcommand --vars argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--vars", "this", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts --vars this --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show hosts --vars this --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+
     def test_show_cmds(self):
 
-        arg_lists = [
-            ('show', 'hosts'),
-            ('show', 'hosts', '--verbose'),
-            ('show', 'hosts', '--vars', 'this'),
-            ('show', 'hosts', '--config', 'this'),
+        arg_lists = []
             ('show', 'modes'),
             ('show', 'modes', '--verbose'),
             ('show', 'modes', '--vars', 'defaulted'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -52,6 +52,45 @@ class ShowTests(unittest.PavTestCase):
         self.assertEqual(output, expected.getvalue(),
                          msg='Loaded Pavilion config was printed instead of the template.')
 
+    def test_config_dirs_subcommand(self):
+        """Test that the config_dirs subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "config_dirs"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show config_dirs terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show config_dirs gave empty output")
+
+    def test_config_dirs_subcommand_format_argument(self):
+        """Test that the config_dirs subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "config_dirs", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show config_dirs --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show config_dirs --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_functions_subcommand(self):
         """Test that the functions subcommand, with no arguments, works as expected."""
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1179,8 +1179,9 @@ class ShowTests(unittest.PavTestCase):
             cmd = ["show", "result_parsers"] + list(combo)
 
             with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                args = parser.parse_args(cmd)
 
-     def test_result_parsers_subcommand_verbose_argument(self):
+    def test_result_parsers_subcommand_verbose_argument(self):
         """Test that the result_parsers subcommand --verbose argument behaves as expected."""
 
         parser = arguments.get_parser()

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1177,14 +1177,14 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes", "slurm"))
+        args = parser.parse_args(("show", "nodes", "dummy"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes slurm terminated with non-zero error code.')
+                         msg='pav show nodes dummy terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
-        self.assertNotEqual(output, "", "pav show nodes slurm gave empty output")
+        self.assertNotEqual(output, "", "pav show nodes dummy gave empty output")
 
     def test_nodes_subcommand_format_argument(self):
         """Test that the nodes subcommand --format argument behaves as expected."""
@@ -1194,17 +1194,17 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes", "slurm", "--format", "json"))
+        args = parser.parse_args(("show", "nodes", "dummy", "--format", "json"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes slurm --format json terminated with non-zero error code.')
+                         msg='pav show nodes dummy --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"pav show nodes slurm --format json did not produce valid JSON. Output\n{output}")
+            self.fail(f"pav show nodes dummy --format json did not produce valid JSON. Output\n{output}")
 
     def test_nodes_subcommand_show_filtered_argument(self):
         """Test that the module_wrappers subcommand --show-filtered argument behaves as expected."""
@@ -1214,14 +1214,14 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes", "slurm", "--show-filtered"))
+        args = parser.parse_args(("show", "nodes", "dummy", "--show-filtered"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes slurm --show-filtered terminated with non-zero error code.')
+                         msg='pav show nodes dummy --show-filtered terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
-        self.assertNotEqual(output, "", "pav show nodes slurm --show-filtered gave empty output")
+        self.assertNotEqual(output, "", "pav show nodes dummy --show-filtered gave empty output")
 
     def test_nodes_subcommand_show_filtered_format(self):
         """Test that the nodes subcommand --show-filtered argument behaves as expected when the
@@ -1232,18 +1232,18 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes", "slurm", "--show-filtered", "--format", "json"))
+        args = parser.parse_args(("show", "nodes", "dummy", "--show-filtered", "--format", "json"))
 
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes slurm --show-filtered --format json terminated with non-zero error code.')
+                         msg='pav show nodes dummy --show-filtered --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"pav show nodes slurm --show-filtered --format json did not produce valid JSON. Output\n{output}")
+            self.fail(f"pav show nodes dummy --show-filtered --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
@@ -1259,7 +1259,7 @@ class ShowTests(unittest.PavTestCase):
 
         for alias in aliases:
             try:
-                args = parser.parse_args(("show", alias, "slurm"))
+                args = parser.parse_args(("show", alias, "dummy"))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
 
@@ -1680,14 +1680,14 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "schedulers", "--vars", "slurm"))
+        args = parser.parse_args(("show", "schedulers", "--vars", "dummy"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show schedulers --vars slurm terminated with non-zero error code.')
+                         msg='pav show schedulers --vars dummy terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
-        self.assertNotEqual(output, "", "pav show schedulers --vars slurm gave empty output")
+        self.assertNotEqual(output, "", "pav show schedulers --vars dummy gave empty output")
 
     def test_schedulers_subcommand_vars_argument_nonexistant(self):
         """Test that the schedulers subcommand --vars argument does not raise an exception when
@@ -1719,17 +1719,17 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "schedulers", "--vars", "slurm", "--format", "json"))
+        args = parser.parse_args(("show", "schedulers", "--vars", "dummy", "--format", "json"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show schedulers --vars slurm --format json terminated with non-zero error code.')
+                         msg='pav show schedulers --vars dummy --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"pav show schedulers --vars slurm --format json did not produce valid JSON. Output\n{output}")
+            self.fail(f"pav show schedulers --vars dummy --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -2507,6 +2507,44 @@ class ShowTests(unittest.PavTestCase):
         error = show_cmd.errfile.getvalue()
         self.assertNotEqual(error, "")
 
+    def test_tests_subcommand_name_filter_argument(self):
+        """Test that name filtering works for the tests subcommand."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "hello*"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests hello* terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show tests hello* gave empty output")
+
+    def test_tests_subcommand_name_filter_nonexistant(self):
+        """Test that the tests subcommand does not raise an exception when a name filter is
+        passed that does not match any tests."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show tests onexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show tests nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
     def test_tests_subcommand_mutual_exclusion(self):
         """Test that the tests subcommand does not allow the --doc and --format
         arguments to be passed at the same time.

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -153,7 +153,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "platforms"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -190,7 +190,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "platforms", "--config", "that"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms --config that terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -251,7 +251,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "platforms", "--verbose"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms --verbose terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -270,7 +270,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "platforms", "--verbose", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms --verbose --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -292,7 +292,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "platforms", "--err"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms --err terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -311,7 +311,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "platforms", "--err", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms --err --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -333,7 +333,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "platforms", "--vars", "that"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms --vars that terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -372,7 +372,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "platforms", "--vars", "that", "--format", "json"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show platforms --vars that --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -394,7 +394,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "hosts"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -431,7 +431,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "hosts", "--config", "this"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts --config this terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -492,7 +492,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "hosts", "--verbose"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts --verbose terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -511,7 +511,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "hosts", "--verbose", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts --verbose --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -533,7 +533,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "hosts", "--vars", "this"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts --vars this terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -572,7 +572,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "hosts", "--vars", "this", "--format", "json"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts --vars this --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -594,7 +594,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "hosts", "--err"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts --err terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -613,7 +613,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "hosts", "--err", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show hosts --err --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -635,7 +635,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "modes"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -672,7 +672,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "modes", "--config", "defaulted"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes --config defaulted terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -733,7 +733,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "modes", "--verbose"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes --verbose terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -752,7 +752,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "modes", "--verbose", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes --verbose --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -774,7 +774,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "modes", "--vars", "defaulted"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes --vars defaulted terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -813,7 +813,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "modes", "--vars", "defaulted", "--format", "json"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes --vars defaulted --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -835,7 +835,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "modes", "--err"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes --err terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -854,7 +854,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "modes", "--err", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show modes --err --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -876,7 +876,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "module_wrappers"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show module_wrappers terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -913,7 +913,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "module_wrappers", "--verbose"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show module_wrappers --verbose terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -932,7 +932,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "module_wrappers", "--verbose", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show module_wrappers --verbose --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -954,7 +954,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "nodes"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show nodes terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -991,7 +991,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "nodes", "--show-filtered"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show nodes --show-filtered terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1010,7 +1010,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "nodes", "--show-filtered", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show nodes --show-filtered --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1032,7 +1032,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "pav_vars"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show pav_vars terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1069,7 +1069,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "result_parsers"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show result_parsers terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1106,7 +1106,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "result_parsers", "--list"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show result_parsers --list terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1124,7 +1124,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "result_parsers", "--list", "--format", "json"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show result_parsers --list --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1146,7 +1146,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "result_parsers", "--doc", "regex"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show result_parsers --doc regex terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1207,7 +1207,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "result_parsers", "--verbose"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show result_parsers --verbose terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1226,7 +1226,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "result_parsers", "--verbose", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show result_parsers --verbose --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1248,7 +1248,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "result_base"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show result_base terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1285,7 +1285,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "schedulers"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1322,7 +1322,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "schedulers", "--config"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers --config terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1362,7 +1362,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "schedulers", "--verbose"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers --verbose terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1381,7 +1381,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "schedulers", "--verbose", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers --verbose --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1403,7 +1403,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "schedulers", "--vars", "slurm"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers --vars slurm terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1442,7 +1442,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "schedulers", "--vars", "slurm", "--format", "json"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers --vars slurm --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1464,7 +1464,7 @@ class ShowTests(unittest.PavTestCase):
 
         args = parser.parse_args(("show", "schedulers", "--list"))
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers --list terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1483,7 +1483,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "schedulers", "--list", "--format", "json"))
 
 
-        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show schedulers --list --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
@@ -1495,6 +1495,181 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_series_subcommand(self):
+        """Test that the series subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show series gave empty output")
+
+    def test_series_subcommand_format_argument(self):
+        """Test that the series subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show series --format json did not produce valid JSON. Output\n{output}")
+
+    def test_series_subcommand_path_argument(self):
+        """Test that the series subcommand works as expected when the --path argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--path"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --path terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show series --path gave empty output")
+
+    def test_series_subcommand_test_sets_argument(self):
+        """Test that the series subcommand --test-sets argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--test-sets"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --test-sets terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show series --test-sets gave empty output")
+
+    def test_series_subcommand_test_sets_format(self):
+        """Test that the series subcommand --test-sets argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--test-sets", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --test-sets --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show series --test-sets --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_series_subcommand_err_argument(self):
+        """Test that the series subcommand --err argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--err"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --err terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show series --err gave empty output")
+
+    def test_series_subcommand_err_format(self):
+        """Test that the series subcommand --err argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--err", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --err --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show series --err --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_series_subcommand_conflicts_argument(self):
+        """Test that the series subcommand --conflicts argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--conflicts"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --conflicts terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show series --conflicts gave empty output")
+
+    def test_series_subcommand_conflicts_format(self):
+        """Test that the series subcommand --conflicts argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--conflicts", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --conflicts --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show series --conflicts --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
     def test_show_cmds(self):
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -2047,10 +2047,26 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_test_config_subcommand(self):
+        """Test that the test_config subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "test_config"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show test_config terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show test_config gave empty output")
+
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'test_config'),
             ('show', 'tests'),
             ('show', 'tests', 'name_filter'),
             ('show', 'tests', '--err'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -91,7 +91,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
-     def test_collections_subcommand(self):
+    def test_collections_subcommand(self):
         """Test that the collections subcommand, with no arguments, works as expected."""
 
         parser = arguments.get_parser()
@@ -1355,7 +1355,7 @@ class ShowTests(unittest.PavTestCase):
         except Exception as e:
             self.fail(f"pav show result_base --format json did not produce valid JSON. Output\n{output}")
 
-      def test_schedulers_subcommand(self):
+    def test_schedulers_subcommand(self):
         """Test that the schedulers subcommand, with no arguments, works as expected."""
 
         parser = arguments.get_parser()
@@ -1812,7 +1812,7 @@ class ShowTests(unittest.PavTestCase):
         except Exception as e:
             self.fail(f"pav show states --format json did not produce valid JSON. Output\n{output}")
 
-     def test_suites_subcommand(self):
+    def test_suites_subcommand(self):
         """Test that the suites subcommand, with no arguments, works as expected."""
 
         parser = arguments.get_parser()
@@ -1971,7 +1971,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
-     def test_system_variables_subcommand(self):
+    def test_system_variables_subcommand(self):
         """Test that the system_variables subcommand, with no arguments, works as expected."""
 
         parser = arguments.get_parser()
@@ -2083,7 +2083,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertNotEqual(output, "", "pav show tests gave empty output")
 
-     def test_tests_subcommand_format_argument(self):
+    def test_tests_subcommand_format_argument(self):
         """Test that the tests subcommand --format argument behaves as expected."""
 
         parser = arguments.get_parser()

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1,7 +1,7 @@
 import io
 import json
 
-from itertools import product
+from itertools import combinations
 
 from pavilion import unittest
 from pavilion import arguments
@@ -214,7 +214,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in product(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "platforms"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
@@ -455,7 +455,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in product(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "hosts"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
@@ -696,7 +696,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in product(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "modes"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
@@ -1191,7 +1191,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in product(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "result_parsers"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
@@ -1346,7 +1346,7 @@ class ShowTests(unittest.PavTestCase):
         ]
 
         for mutex_args in mutex_sets:
-            for combo in product(mutex_args, repeat=2):
+            for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "schedulers"] + list(combo)
 
                 with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -2291,9 +2291,6 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        # Capture output
-        show_cmd.outfile = io.StringIO()
-
         for sub in self.FORMATTABLE_SUBCMDS:
             args = parser.parse_args(['show', sub, '--format', 'json'])
             ret = show_cmd.run(self.pav_cfg, args)
@@ -2319,7 +2316,6 @@ class ShowTests(unittest.PavTestCase):
         parser = arguments.get_parser()
         show_cmd = commands.get_command('show')
         show_cmd.silence()
-        show_cmd.outfile = io.StringIO()
 
         for sub in self.FORMATTABLE_SUBCMDS:
             args = parser.parse_args(['show', sub, '--format', 'table'])
@@ -2336,7 +2332,6 @@ class ShowTests(unittest.PavTestCase):
         parser = arguments.get_parser()
         show_cmd = commands.get_command('show')
         show_cmd.silence()
-        show_cmd.outfile = io.StringIO()
 
         for sub in self.FORMATTABLE_SUBCMDS:
             args = parser.parse_args(['show', sub, '--format', 'list'])
@@ -2346,3 +2341,28 @@ class ShowTests(unittest.PavTestCase):
             self.assertTrue(output.strip(), f"Expected non-empty list output for '{sub}'")
             show_cmd.outfile.truncate(0)
             show_cmd.outfile.seek(0)
+
+    def test_show_format_list_parsable(self):
+        """Test that the output from --format list is parsable by simple Linux utilities and
+        that it does not output a header."""
+
+        parser = arguments.get_parser()
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(['show', 'schedulers', '--format', 'list'])
+
+        ret = show_cmd.run(self.pav_cfg, args)
+        self.assertEqual(ret, 0)
+
+        output = show_cmd.outfile.getvalue()
+
+        lines = subprocess.run(
+            ["wc", "-l"],
+            input=output,
+            universal_newlines=True,
+            capture_output=True,
+            check=True
+        )
+
+        self.assertEqual(int(lines.stdout.strip()), 3, msg='Expected three lines of output from pav show schedulers --format list')

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1030,12 +1030,179 @@ class ShowTests(unittest.PavTestCase):
         except Exception as e:
             self.fail(f"pav show nodes --format json did not produce valid JSON. Output\n{output}")
 
+    def test_result_parsers_subcommand(self):
+        """Test that the result_parsers subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show result_parsers terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show result_parsers gave empty output")
+
+    def test_result_parsers_subcommand_format_argument(self):
+        """Test that the result_parsers subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show result_parsers --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show result_parsers --format json did not produce valid JSON. Output\n{output}")
+
+    def test_result_parsers_subcommand_list_argument(self):
+        """Test that the result_parsers subcommand --list argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers", "--list"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show result_parsers --list terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show result_parsers --list gave empty output")
+
+    def test_result_parsers_subcommand_list_format(self):
+        """Test that the modes subcommand --list argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers", "--list", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show result_parsers --list --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show result_parsers --list --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+      def test_result_parsers_subcommand_doc_argument(self):
+        """Test that the modes subcommand --doc argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers", "--doc", "regex"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show result_parsers --doc regex terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show result_parsers --doc regex gave empty output")
+
+    def test_result_parsers_subcommand_doc_argument_nonexistant(self):
+        """Test that the result_parsers subcommand --doc argument does not raise an exception when
+        passed a non-existant result parser."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers", "--doc", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show result_parsers --doc nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show result_parsers --doc nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_result_parsers_subcommand_mutual_exclusion(self):
+        """Test that the result_parsers subcommand does not allow the --doc and --format
+        arguments to be passed at the same time.
+
+        Note that this test does not test whether main.py catches the error raised by argparse."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        with self.assertRaises(SystemExit):
+            args = parser.parse_args(("show", "result_parsers", "--format", "json", "--doc", "regex"))
+
+     def test_result_parsers_subcommand_verbose_argument(self):
+        """Test that the result_parsers subcommand --verbose argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show result_parsers --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show result_parsers --verbose gave empty output")
+
+    def test_result_parsers_subcommand_verbose_format(self):
+        """Test that the result_parsers subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_parsers", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show result_parsers --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show result_parsers --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'result_parsers'),
-            ('show', 'result_parsers', '--doc=regex'),
-            ('show', 'result_parsers', '--verbose'),
             ('show', 'sched'),
             ('show', 'sched', '--config'),
             ('show', 'sched', '--vars=slurm'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1,5 +1,6 @@
 import io
 import json
+import subprocess
 
 from itertools import combinations
 
@@ -1032,14 +1033,14 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes"))
+        args = parser.parse_args(("show", "nodes", "slurm"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes terminated with non-zero error code.')
+                         msg='pav show nodes slurm terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
-        self.assertNotEqual(output, "", "pav show nodes gave empty output")
+        self.assertNotEqual(output, "", "pav show nodes slurm gave empty output")
 
     def test_nodes_subcommand_format_argument(self):
         """Test that the nodes subcommand --format argument behaves as expected."""
@@ -1049,17 +1050,17 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes", "--format", "json"))
+        args = parser.parse_args(("show", "nodes", "slurm", "--format", "json"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes --format json terminated with non-zero error code.')
+                         msg='pav show nodes slurm --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"pav show nodes --format json did not produce valid JSON. Output\n{output}")
+            self.fail(f"pav show nodes slurm --format json did not produce valid JSON. Output\n{output}")
 
     def test_nodes_subcommand_show_filtered_argument(self):
         """Test that the module_wrappers subcommand --show-filtered argument behaves as expected."""
@@ -1069,14 +1070,14 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes", "--show-filtered"))
+        args = parser.parse_args(("show", "nodes", "slurm", "--show-filtered"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes --show-filtered terminated with non-zero error code.')
+                         msg='pav show nodes slurm --show-filtered terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
-        self.assertNotEqual(output, "", "pav show nodes --show-filtered gave empty output")
+        self.assertNotEqual(output, "", "pav show nodes slurm --show-filtered gave empty output")
 
     def test_nodes_subcommand_show_filtered_format(self):
         """Test that the nodes subcommand --show-filtered argument behaves as expected when the
@@ -1087,18 +1088,18 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "nodes", "--show-filtered", "--format", "json"))
+        args = parser.parse_args(("show", "nodes", "slurm", "--show-filtered", "--format", "json"))
 
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show nodes --show-filtered --format json terminated with non-zero error code.')
+                         msg='pav show nodes slurm --show-filtered --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"pav show nodes --show-filtered --format json did not produce valid JSON. Output\n{output}")
+            self.fail(f"pav show nodes slurm --show-filtered --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
@@ -2360,8 +2361,9 @@ class ShowTests(unittest.PavTestCase):
         lines = subprocess.run(
             ["wc", "-l"],
             input=output,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             universal_newlines=True,
-            capture_output=True,
             check=True
         )
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -91,6 +91,45 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+     def test_collections_subcommand(self):
+        """Test that the collections subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "collections"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show collections terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show collections gave empty output")
+
+    def test_collections_subcommand_format_argument(self):
+        """Test that the collections subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "collections", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show collections --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show collections --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_functions_subcommand(self):
         """Test that the functions subcommand, with no arguments, works as expected."""
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1549,6 +1549,30 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertNotEqual(output, "", "pav show series --path gave empty output")
 
+    def test_series_subcommand_path_format(self):
+        """Test that the series subcommand --path argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "series", "--path", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show series --path --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show series --path --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_series_subcommand_test_sets_argument(self):
         """Test that the series subcommand --test-sets argument behaves as expected."""
 
@@ -1708,13 +1732,168 @@ class ShowTests(unittest.PavTestCase):
         except Exception as e:
             self.fail(f"pav show states --format json did not produce valid JSON. Output\n{output}")
 
+     def test_suites_subcommand(self):
+        """Test that the suites subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show suites gave empty output")
+
+    def test_suites_subcommand_format_argument(self):
+        """Test that the suites subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show suites --format json did not produce valid JSON. Output\n{output}")
+
+    def test_suites_subcommand_verbose_argument(self):
+        """Test that the suites subcommand works as expected when the --verbose argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show suites --verbose gave empty output")
+
+    def test_suites_subcommand_verbose_format(self):
+        """Test that the suites subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show suites --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_suites_subcommand_err_argument(self):
+        """Test that the suites subcommand --err argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites", "--err"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites --err terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show suites --err gave empty output")
+
+    def test_suites_subcommand_err_format(self):
+        """Test that the suites subcommand --err argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites", "--err", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites --err --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show suites --err --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_suites_subcommand_supersedes_argument(self):
+        """Test that the suites subcommand --supersedes argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites", "--supersedes"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites --supersedes terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show suites --supersedes gave empty output")
+
+    def test_suites_subcommand_supersedes_format(self):
+        """Test that the suites subcommand --supersedes argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "suites", "--supersedes", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show suites --supersedes --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show suites --supersedes --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'suites'),
-            ('show', 'suites', '--err'),
-            ('show', 'suites', '--supersedes'),
-            ('show', 'suites', '--verbose'),
             ('show', 'system_variables'),
             ('show', 'system_variables', '--verbose'),
             ('show', 'test_config'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1222,6 +1222,43 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_result_base_subcommand(self):
+        """Test that the result_base subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_base"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show result_base terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show result_base gave empty output")
+
+    def test_result_base_subcommand_format_argument(self):
+        """Test that the result_base subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "result_base", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show result_base --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show result_base --format json did not produce valid JSON. Output\n{output}")
+
     def test_show_cmds(self):
 
         arg_lists = [

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -197,7 +197,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertNotEqual(output, "", "pav show platforms --config that gave empty output")
 
-    def test_platforms_subcommand_config_mutual_exclusion(self):
+    def test_platforms_subcommand_mutual_exclusion(self):
         """Test that the platforms subcommand correctly disallows certain combinations of
         arguments.
 
@@ -208,13 +208,17 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        mutex_args = ("--format json", "--config that", "--err", "--vars", "--verbose")
+        mutex_sets = [
+            ("--config that", "--err", "--vars", "--verbose"),
+            ("--format json", "--config that")
+        ]
 
-        for combo in product(mutex_args, repeat=2):
-            cmd = ["show", "platforms"] + list(combo)
+        for mutex_args in mutex_sets:
+            for combo in product(mutex_args, repeat=2):
+                cmd = ["show", "platforms"] + list(combo)
 
-            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
-                args = parser.parse_args(cmd)
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                    args = parser.parse_args(cmd)
 
     def test_platforms_subcommand_config_argument_nonexistant(self):
         """Test that the platforms subcommand --config argument does not raise an exception when
@@ -434,7 +438,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertNotEqual(output, "", "pav show hosts --config this gave empty output")
 
-    def test_hosts_subcommand_config_mutual_exclusion(self):
+    def test_hosts_subcommand_mutual_exclusion(self):
         """Test that the hosts subcommand correctly disallows certain combinations of
         arguments.
 
@@ -445,13 +449,17 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        mutex_args = ("--format json", "--config this", "--err", "--vars", "--verbose")
+        mutex_sets = [
+            ("--config this", "--err", "--vars", "--verbose"),
+            ("--format json", "--config this")
+        ]
 
-        for combo in product(mutex_args, repeat=2):
-            cmd = ["show", "hosts"] + list(combo)
+        for mutex_args in mutex_sets:
+            for combo in product(mutex_args, repeat=2):
+                cmd = ["show", "hosts"] + list(combo)
 
-            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
-                args = parser.parse_args(cmd)
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                    args = parser.parse_args(cmd)
 
     def test_hosts_subcommand_config_argument_nonexistant(self):
         """Test that the hosts subcommand --config argument does not raise an exception when
@@ -671,7 +679,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertNotEqual(output, "", "pav show modes --config defaulted gave empty output")
 
-    def test_modes_subcommand_config_mutual_exclusion(self):
+    def test_modes_subcommand_mutual_exclusion(self):
         """Test that the modes subcommand correctly disallows certain combinations of
         arguments.
 
@@ -682,13 +690,17 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        mutex_args = ("--format json", "--config that", "--err", "--vars", "--verbose")
+        mutex_sets = [
+            ("--config that", "--err", "--vars", "--verbose"),
+            ("--format json", "--config that")
+        ]
 
-        for combo in product(mutex_args, repeat=2):
-            cmd = ["show", "modes"] + list(combo)
+        for mutex_args in mutex_sets:
+            for combo in product(mutex_args, repeat=2):
+                cmd = ["show", "modes"] + list(combo)
 
-            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
-                args = parser.parse_args(cmd)
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                    args = parser.parse_args(cmd)
 
     def test_modes_subcommand_config_argument_nonexistant(self):
         """Test that the modes subcommand --config argument does not raise an exception when
@@ -1173,13 +1185,17 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        mutex_args = ("--format json", "--list", "--doc regex", "--verbose")
+        mutex_sets = [
+            ("--list", "--doc regex", "--verbose"),
+            ("--format json", "--doc regex")
+        ]
 
-        for combo in product(mutex_args, repeat=2):
-            cmd = ["show", "result_parsers"] + list(combo)
+        for mutex_args in mutex_sets:
+            for combo in product(mutex_args, repeat=2):
+                cmd = ["show", "result_parsers"] + list(combo)
 
-            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
-                args = parser.parse_args(cmd)
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                    args = parser.parse_args(cmd)
 
     def test_result_parsers_subcommand_verbose_argument(self):
         """Test that the result_parsers subcommand --verbose argument behaves as expected."""
@@ -1259,12 +1275,230 @@ class ShowTests(unittest.PavTestCase):
         except Exception as e:
             self.fail(f"pav show result_base --format json did not produce valid JSON. Output\n{output}")
 
+      def test_schedulers_subcommand(self):
+        """Test that the schedulers subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show schedulers gave empty output")
+
+    def test_schedulers_subcommand_format_argument(self):
+        """Test that the schedulers subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show schedulers --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show schedulers --format json did not produce valid JSON. Output\n{output}")
+
+    def test_schedulers_subcommand_config_argument(self):
+        """Test that the schedulers subcommand works as expected when the --config argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--config"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers --config terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show modes --config gave empty output")
+
+    def test_schedulers_subcommand_mutual_exclusion(self):
+        """Test that the schedulers subcommand correctly disallows certain combinations of
+        arguments.
+
+        Note that this test does not test whether main.py catches the error raised by argparse."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        mutex_sets = [
+            ("--list", "--config", "--vars", "--verbose"),
+            ("--format json", "--config")
+        ]
+
+        for mutex_args in mutex_sets:
+            for combo in product(mutex_args, repeat=2):
+                cmd = ["show", "schedulers"] + list(combo)
+
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                    args = parser.parse_args(cmd)
+
+    def test_schedulers_subcommand_verbose_argument(self):
+        """Test that the schedulers subcommand --verbose argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show schedulers --verbose gave empty output")
+
+    def test_schedulers_subcommand_verbose_format(self):
+        """Test that the schedulers subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show schedulers --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_schedulers_subcommand_vars_argument(self):
+        """Test that the schedulers subcommand --vars argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--vars", "slurm"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers --vars slurm terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show schedulers --vars slurm gave empty output")
+
+    def test_schedulers_subcommand_vars_argument_nonexistant(self):
+        """Test that the schedulers subcommand --vars argument does not raise an exception when
+        passed a non-existant host."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--vars", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show schedulers --vars nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show schedulers --vars nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_schedulers_subcommand_vars_format(self):
+        """Test that the schedulers subcommand --vars argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--vars", "slurm", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers --vars slurm --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show schedulers --vars slurm --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_schedulers_subcommand_list_argument(self):
+        """Test that the schedulers subcommand --list argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--list"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers --list terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show schedulers --list gave empty output")
+
+    def test_schedulers_subcommand_list_format(self):
+        """Test that the schedulers subcommand --list argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "schedulers", "--list", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show schedulers --list --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show schedulers --list --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'sched'),
-            ('show', 'sched', '--config'),
-            ('show', 'sched', '--vars=slurm'),
             ('show', 'states'),
             ('show', 'suites'),
             ('show', 'suites', '--err'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -837,7 +837,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
-     def test_module_wrappers_subcommand(self):
+    def test_module_wrappers_subcommand(self):
         """Test that the module_wrappers subcommand, with no arguments, works as expected."""
 
         parser = arguments.get_parser()

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1671,10 +1671,46 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_states_subcommand(self):
+        """Test that the states subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "states"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show states terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show states gave empty output")
+
+    def test_states_subcommand_format_argument(self):
+        """Test that the states subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "states", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show states --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show states --format json did not produce valid JSON. Output\n{output}")
+
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'states'),
             ('show', 'suites'),
             ('show', 'suites', '--err'),
             ('show', 'suites', '--supersedes'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1259,7 +1259,7 @@ class ShowTests(unittest.PavTestCase):
 
         for alias in aliases:
             try:
-                args = parser.parse_args(("show", alias))
+                args = parser.parse_args(("show", alias, "slurm"))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -993,11 +993,46 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_pav_vars_subcommand(self):
+        """Test that the pav_vars subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "pav_vars"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show pav_vars terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show pav_vars gave empty output")
+
+    def test_pav_vars_subcommand_format_argument(self):
+        """Test that the pav_vars subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "pav_vars", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show pav_vars --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show nodes --format json did not produce valid JSON. Output\n{output}")
 
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'pav_vars'),
             ('show', 'result_parsers'),
             ('show', 'result_parsers', '--doc=regex'),
             ('show', 'result_parsers', '--verbose'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -837,12 +837,87 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+     def test_module_wrappers_subcommand(self):
+        """Test that the module_wrappers subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "module_wrappers"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show module_wrappers terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show module_wrappers gave empty output")
+
+    def test_module_wrappers_format_argument(self):
+        """Test that the module_wrappers subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "module_wrappers", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show module_wrappers --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show module_wrappers --format json did not produce valid JSON. Output\n{output}")
+
+    def test_module_wrappers_subcommand_verbose_argument(self):
+        """Test that the module_wrappers subcommand --verbose argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "module_wrappers", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show module_wrappers --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show module_wrappers --verbose gave empty output")
+
+    def test_moddule_wrappers_subcommand_verbose_format(self):
+        """Test that the module_wrappers subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "module_wrappers", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show module_wrappers --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show module_wrappers --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'module_wrappers'),
-            ('show', 'module_wrappers', '--verbose'),
             ('show', 'pav_vars'),
             ('show', 'result_parsers'),
             ('show', 'result_parsers', '--doc=regex'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -891,7 +891,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertNotEqual(output, "", "pav show module_wrappers --verbose gave empty output")
 
-    def test_moddule_wrappers_subcommand_verbose_format(self):
+    def test_module_wrappers_subcommand_verbose_format(self):
         """Test that the module_wrappers subcommand --verbose argument behaves as expected when the
         --format argument is also passed."""
 
@@ -914,6 +914,85 @@ class ShowTests(unittest.PavTestCase):
             self.fail(f"pav show module_wrappers --verbose --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_nodes_subcommand(self):
+        """Test that the nodes subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "nodes"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show nodes terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show nodes gave empty output")
+
+    def test_nodes_subcommand_format_argument(self):
+        """Test that the nodes subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "nodes", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show nodes --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show nodes --format json did not produce valid JSON. Output\n{output}")
+
+    def test_nodes_subcommand_show_filtered_argument(self):
+        """Test that the module_wrappers subcommand --show-filtered argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "nodes", "--show-filtered"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show nodes --show-filtered terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show nodes --show-filtered gave empty output")
+
+    def test_nodes_subcommand_show_filtered_format(self):
+        """Test that the nodes subcommand --show-filtered argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "nodes", "--show-filtered", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show nodes --show-filtered --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show nodes --show-filtered --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
 
     def test_show_cmds(self):
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -66,8 +66,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_config_dirs_subcommand(self):
         """Test that the config_dirs subcommand, with no arguments, works as expected."""
@@ -121,9 +123,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
-
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_collections_subcommand(self):
         """Test that the collections subcommand, with no arguments, works as expected."""
@@ -177,9 +180,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
-
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_functions_subcommand(self):
         """Test that the functions subcommand, with no arguments, works as expected."""
@@ -287,8 +291,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_platforms_subcommand(self):
         """Test that the platforms subcommand, with no arguments, works as expected."""
@@ -544,8 +550,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_hosts_subcommand(self):
         """Test that the hosts subcommand, with no arguments, works as expected."""
@@ -801,8 +809,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_modes_subcommand(self):
         """Test that the modes subcommand, with no arguments, works as expected."""
@@ -1058,8 +1068,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_module_wrappers_subcommand(self):
         """Test that the module_wrappers subcommand, with no arguments, works as expected."""
@@ -1152,8 +1164,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_nodes_subcommand(self):
         """Test that the nodes subcommand, with no arguments, works as expected."""
@@ -1246,8 +1260,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_pavilion_variables_subcommand(self):
         """Test that the pavilion_variables subcommand, with no arguments, works as expected."""
@@ -1299,8 +1315,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_result_parsers_subcommand(self):
         """Test that the result_parsers subcommand, with no arguments, works as expected."""
@@ -1494,8 +1512,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_result_base_subcommand(self):
         """Test that the result_base subcommand, with no arguments, works as expected."""
@@ -1767,8 +1787,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_series_subcommand(self):
         """Test that the series subcommand, with no arguments, works as expected."""
@@ -2020,8 +2042,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_suites_subcommand(self):
         """Test that the suites subcommand, with no arguments, works as expected."""
@@ -2195,8 +2219,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_system_variables_subcommand(self):
         """Test that the system_variables subcommand, with no arguments, works as expected."""
@@ -2289,8 +2315,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     def test_test_config_subcommand(self):
         """Test that the test_config subcommand, with no arguments, works as expected."""
@@ -2537,7 +2565,7 @@ class ShowTests(unittest.PavTestCase):
 
         try:
             self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
-                            msg='pav show tests onexistant terminated with error code 0 despite bad input.')
+                            msg='pav show tests nonexistant terminated with error code 0 despite bad input.')
         except Exception as err:
             self.fail(f"pav show tests nonexistant raised the following error:\n{err}")
 
@@ -2574,8 +2602,10 @@ class ShowTests(unittest.PavTestCase):
         for alias in aliases:
             args = parser.parse_args(("show", alias))
 
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg=f"Alias pav show {alias} was not recognized.")
+            try:
+                show_cmd.run(self.pav_cfg, args)
+            except SystemExit:
+                self.fail(f"Alias pav show {alias} was not recognized.")
 
     FORMATTABLE_SUBCMDS = ('config_dirs', 'collections', 'functions', 'platform', 'hosts', 'modes',
                         'module_wrappers', 'pav_vars', 'result_parsers', 'result_base',

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -218,8 +218,10 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        with self.assertRaises(SystemExit):
-            args = parser.parse_args(("show", "functions", "--format", "json", "--detail", "int"))
+        cmd = ("show", "functions", "--format", "json", "--detail", "int")
+
+        with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: ('--format json', '--detail int')"):
+            args = parser.parse_args(cmd)
 
     def test_platforms_subcommand(self):
         """Test that the platforms subcommand, with no arguments, works as expected."""
@@ -295,7 +297,7 @@ class ShowTests(unittest.PavTestCase):
             for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "platforms"] + list(combo)
 
-                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
                     args = parser.parse_args(cmd)
 
     def test_platforms_subcommand_config_argument_nonexistant(self):
@@ -536,7 +538,7 @@ class ShowTests(unittest.PavTestCase):
             for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "hosts"] + list(combo)
 
-                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
                     args = parser.parse_args(cmd)
 
     def test_hosts_subcommand_config_argument_nonexistant(self):
@@ -777,7 +779,7 @@ class ShowTests(unittest.PavTestCase):
             for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "modes"] + list(combo)
 
-                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
                     args = parser.parse_args(cmd)
 
     def test_modes_subcommand_config_argument_nonexistant(self):
@@ -1272,7 +1274,7 @@ class ShowTests(unittest.PavTestCase):
             for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "result_parsers"] + list(combo)
 
-                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
                     args = parser.parse_args(cmd)
 
     def test_result_parsers_subcommand_verbose_argument(self):
@@ -1427,7 +1429,7 @@ class ShowTests(unittest.PavTestCase):
             for combo in combinations(mutex_args, repeat=2):
                 cmd = ["show", "schedulers"] + list(combo)
 
-                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: {combo}"):
                     args = parser.parse_args(cmd)
 
     def test_schedulers_subcommand_verbose_argument(self):
@@ -2064,25 +2066,219 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertNotEqual(output, "", "pav show test_config gave empty output")
 
-    def test_show_cmds(self):
-
-        arg_lists = [
-            ('show', 'tests'),
-            ('show', 'tests', 'name_filter'),
-            ('show', 'tests', '--err'),
-            ('show', 'tests', '--doc', 'hello_world.narf'),
-            ('show', 'tests', '--hidden'),
-            ('show', 'tests', '--verbose'),
-        ]
+    def test_tests_subcommand(self):
+        """Test that the tests subcommand, with no arguments, works as expected."""
 
         parser = arguments.get_parser()
 
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        for arg_list in arg_lists:
-            args = parser.parse_args(arg_list)
-            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0)
+        args = parser.parse_args(("show", "tests"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show tests gave empty output")
+
+     def test_tests_subcommand_format_argument(self):
+        """Test that the tests subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show tests --format json did not produce valid JSON. Output\n{output}")
+
+    def test_tests_subcommand_verbose_argument(self):
+        """Test that the tests subcommand works as expected when the --verbose argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show tests --verbose gave empty output")
+
+    def test_tests_subcommand_verbose_format(self):
+        """Test that the tests subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show tests --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_tests_subcommand_hidden_argument(self):
+        """Test that the tests subcommand works as expected when the --hidden argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--hidden"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --hidden terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show tests --hidden gave empty output")
+
+    def test_tests_subcommand_hidden_format(self):
+        """Test that the tests subcommand --hidden argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--hidden", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --hidden --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show tests --hidden --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_tests_subcommand_err_argument(self):
+        """Test that the tests subcommand works as expected when the --err argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--err"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --err terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show tests --err gave empty output")
+
+    def test_tests_subcommand_err_format(self):
+        """Test that the tests subcommand --err argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--err", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --err --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show tests --hidden --err json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_tests_subcommand_doc_argument(self):
+        """Test that the tests subcommand works as expected when the --doc argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--doc", "hello_world.narf"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show tests --doc hello_world.narf terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show tests --doc hello_world.narf gave empty output")
+
+    def test_tests_subcommand_doc_argument_nonexistant(self):
+        """Test that the tests subcommand --doc argument does not raise an exception when
+        passed a non-existant test."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "tests", "--doc", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show tests --doc nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show tests --doc nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard error
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_tests_subcommand_mutual_exclusion(self):
+        """Test that the tests subcommand does not allow the --doc and --format
+        arguments to be passed at the same time.
+
+        Note that this test does not test whether main.py catches the error raised by argparse."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        cmd = ("show", "tests", "--format", "json", "--doc", "hello_world.narf")
+
+        with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not disallow the following combination of arguments: ('--format json', '--doc hello_world.narf')"):
+            args = parser.parse_args(cmd)
 
     FORMATTABLE_SUBCMDS = ('config_dirs', 'collections', 'functions', 'platform', 'hosts', 'modes',
                         'module_wrappers', 'pav_vars', 'result_parsers', 'result_base',

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1124,7 +1124,7 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
-      def test_result_parsers_subcommand_doc_argument(self):
+    def test_result_parsers_subcommand_doc_argument(self):
         """Test that the modes subcommand --doc argument behaves as expected."""
 
         parser = arguments.get_parser()

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -238,7 +238,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show functions --detail nonexistant should have written a message to stderr, but did not.')
 
     def test_functions_subcommand_format_argument(self):
         """Test that the functions subcommand --format argument behaves as expected."""
@@ -392,7 +392,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show platforms --config nonexistant should have written a message to stderr, but did not.')
 
     def test_platforms_subcommand_verbose_argument(self):
         """Test that the platforms subcommand --verbose argument behaves as expected."""
@@ -512,7 +512,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show platforms --vars nonexistant should have written a message to stderr, but did not.')
 
     def test_platforms_subcommand_vars_format(self):
         """Test that the platforms subcommand --vars argument behaves as expected when the
@@ -651,7 +651,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show hosts --config nonexistant should have written a message to stderr, but did not.')
 
     def test_hosts_subcommand_verbose_argument(self):
         """Test that the hosts subcommand --verbose argument behaves as expected."""
@@ -730,7 +730,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show hosts --vars nonexistant should have written a message to stderr, but did not.')
 
     def test_hosts_subcommand_vars_format(self):
         """Test that the hosts subcommand --vars argument behaves as expected when the
@@ -910,7 +910,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show modes --config nonexistant should have written a message to stderr, but did not.')
 
     def test_modes_subcommand_verbose_argument(self):
         """Test that the modes subcommand --verbose argument behaves as expected."""
@@ -989,7 +989,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show modes --vars nonexistant should have written a message to stderr, but did not.')
 
     def test_modes_subcommand_vars_format(self):
         """Test that the modes subcommand --vars argument behaves as expected when the
@@ -1433,7 +1433,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show result_parsers --doc nonexistant should have written a message to stderr, but did not.')
 
     def test_result_parsers_subcommand_mutual_exclusion(self):
         """Test that the platforms subcommand correctly disallows certain combinations of
@@ -1708,7 +1708,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show schedulers --vars nonexistant should have written a message to stderr, but did not.')
 
     def test_schedulers_subcommand_vars_format(self):
         """Test that the schedulers subcommand --vars argument behaves as expected when the
@@ -2533,7 +2533,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show tests --doc nonexistant should have written a message to stderr, but did not.')
 
     def test_tests_subcommand_name_filter_argument(self):
         """Test that name filtering works for the tests subcommand."""
@@ -2571,7 +2571,7 @@ class ShowTests(unittest.PavTestCase):
 
         # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
-        self.assertNotEqual(error, "")
+        self.assertNotEqual(error, "", msg='pav show tests nonexistant should have written a message to stderr, but did not.')
 
     def test_tests_subcommand_mutual_exclusion(self):
         """Test that the tests subcommand does not allow the --doc and --format
@@ -2693,4 +2693,4 @@ class ShowTests(unittest.PavTestCase):
             check=True
         )
 
-        self.assertEqual(int(lines.stdout.strip()), 3, msg='Expected three lines of output from pav show schedulers --format list')
+        self.assertEqual(int(lines.stdout.strip()), 3, msg=f'Expected three lines of output from pav show schedulers --format list. Output\n{lines.stdout}')

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -2693,4 +2693,4 @@ class ShowTests(unittest.PavTestCase):
             check=True
         )
 
-        self.assertEqual(int(lines.stdout.strip()), 3, msg=f'Expected three lines of output from pav show schedulers --format list. Output\n{lines.stdout}')
+        self.assertEqual(int(lines.stdout.strip()), 6, msg=f'Expected 6 lines of output from pav show schedulers --format list. Output:\n{output}')

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1891,11 +1891,87 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+     def test_system_variables_subcommand(self):
+        """Test that the system_variables subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "system_variables"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show system_variables terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show system_variables gave empty output")
+
+    def test_system_variables_subcommand_format_argument(self):
+        """Test that the system_variables subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "system_variables", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show system_variables --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show system_variables --format json did not produce valid JSON. Output\n{output}")
+
+    def test_system_variables_subcommand_verbose_argument(self):
+        """Test that the system_variables subcommand works as expected when the --verbose argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "system_variables", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show system_variables --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show system_variables --verbose gave empty output")
+
+    def test_system_variables_subcommand_verbose_format(self):
+        """Test that the system_variables subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "system_variables", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show system_variables --verbose --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show system_variables --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'system_variables'),
-            ('show', 'system_variables', '--verbose'),
             ('show', 'test_config'),
             ('show', 'tests'),
             ('show', 'tests', 'name_filter'),

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -564,6 +564,47 @@ class ShowTests(unittest.PavTestCase):
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
+    def test_hosts_subcommand_err_argument(self):
+        """Test that the hosts subcommand --err argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--err"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts --err terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show hosts --err gave empty output")
+
+    def test_hosts_subcommand_err_format(self):
+        """Test that the hosts subcommand --err argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "hosts", "--err", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show hosts --err --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show hosts --err --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_modes_subcommand(self):
         """Test that the modes subcommand, with no arguments, works as expected."""
 
@@ -752,6 +793,47 @@ class ShowTests(unittest.PavTestCase):
             data = json.loads(output)
         except Exception as e:
             self.fail(f"pav show modes --vars defaulted --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_modes_subcommand_err_argument(self):
+        """Test that the modes subcommand --err argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--err"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes --err terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show modes --err gave empty output")
+
+    def test_modes_subcommand_err_format(self):
+        """Test that the modes subcommand --err argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "modes", "--err", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show modes --err --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show modes --err --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -64,12 +64,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("config", "conf")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_config_dirs_subcommand(self):
         """Test that the config_dirs subcommand, with no arguments, works as expected."""
@@ -121,12 +121,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("config_dirs", "config_dir")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_collections_subcommand(self):
         """Test that the collections subcommand, with no arguments, works as expected."""
@@ -178,12 +178,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("collections", "collection")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_functions_subcommand(self):
         """Test that the functions subcommand, with no arguments, works as expected."""
@@ -289,12 +289,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("functions", "functions", "func")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_platforms_subcommand(self):
         """Test that the platforms subcommand, with no arguments, works as expected."""
@@ -548,12 +548,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("platforms", "platform")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_hosts_subcommand(self):
         """Test that the hosts subcommand, with no arguments, works as expected."""
@@ -807,12 +807,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("hosts", "host")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_modes_subcommand(self):
         """Test that the modes subcommand, with no arguments, works as expected."""
@@ -1066,12 +1066,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("modes", "mode")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_module_wrappers_subcommand(self):
         """Test that the module_wrappers subcommand, with no arguments, works as expected."""
@@ -1162,12 +1162,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("module_wrappers", "module_wrapper", "mod", "modules", "module", "wrappers", "wrapper")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_nodes_subcommand(self):
         """Test that the nodes subcommand, with no arguments, works as expected."""
@@ -1258,12 +1258,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("nodes", "node")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_pavilion_variables_subcommand(self):
         """Test that the pavilion_variables subcommand, with no arguments, works as expected."""
@@ -1313,12 +1313,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("pavilion_variables", "pavilion_variable", "pav_vars", "pav_vars", "pav")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_result_parsers_subcommand(self):
         """Test that the result_parsers subcommand, with no arguments, works as expected."""
@@ -1510,12 +1510,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("result_parsers", "result_parser", "parsers", "parser", "result")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_result_base_subcommand(self):
         """Test that the result_base subcommand, with no arguments, works as expected."""
@@ -1785,12 +1785,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("schedulers", "scheduler", "sched")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_series_subcommand(self):
         """Test that the series subcommand, with no arguments, works as expected."""
@@ -2040,12 +2040,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("states", "state")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_suites_subcommand(self):
         """Test that the suites subcommand, with no arguments, works as expected."""
@@ -2217,12 +2217,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("suites", "suite")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_system_variables_subcommand(self):
         """Test that the system_variables subcommand, with no arguments, works as expected."""
@@ -2313,12 +2313,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("system_variables", "system_variable", "sys_vars", "sys_var", "sys")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     def test_test_config_subcommand(self):
         """Test that the test_config subcommand, with no arguments, works as expected."""
@@ -2600,12 +2600,12 @@ class ShowTests(unittest.PavTestCase):
         aliases = ("tests", "test")
 
         for alias in aliases:
-            args = parser.parse_args(("show", alias))
-
             try:
-                show_cmd.run(self.pav_cfg, args)
+                args = parser.parse_args(("show", alias))
             except SystemExit:
                 self.fail(f"Alias pav show {alias} was not recognized.")
+
+            self.assertEqual(show_cmd.run(self.pav_cfg, args), 0, msg=f"Alias pav show {alias} was not recognized.")
 
     FORMATTABLE_SUBCMDS = ('config_dirs', 'collections', 'functions', 'platform', 'hosts', 'modes',
                         'module_wrappers', 'pav_vars', 'result_parsers', 'result_base',

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -1,6 +1,8 @@
 import io
 import json
 
+from itertools import product
+
 from pavilion import unittest
 from pavilion import arguments
 from pavilion import plugins
@@ -196,8 +198,8 @@ class ShowTests(unittest.PavTestCase):
         self.assertNotEqual(output, "", "pav show platforms --config that gave empty output")
 
     def test_platforms_subcommand_config_mutual_exclusion(self):
-        """Test that the platforms subcommand does not allow the --config and --format
-        arguments to be passed at the same time.
+        """Test that the platforms subcommand correctly disallows certain combinations of
+        arguments.
 
         Note that this test does not test whether main.py catches the error raised by argparse."""
 
@@ -206,8 +208,13 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        with self.assertRaises(SystemExit):
-            args = parser.parse_args(("show", "platforms", "--format", "json", "--config", "that"))
+        mutex_args = ("--format json", "--config that", "--err", "--vars", "--verbose")
+
+        for combo in product(mutex_args, repeat=2):
+            cmd = ["show", "platforms"] + list(combo)
+
+            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                args = parser.parse_args(cmd)
 
     def test_platforms_subcommand_config_argument_nonexistant(self):
         """Test that the platforms subcommand --config argument does not raise an exception when
@@ -428,8 +435,8 @@ class ShowTests(unittest.PavTestCase):
         self.assertNotEqual(output, "", "pav show hosts --config this gave empty output")
 
     def test_hosts_subcommand_config_mutual_exclusion(self):
-        """Test that the hosts subcommand does not allow the --config and --format
-        arguments to be passed at the same time.
+        """Test that the hosts subcommand correctly disallows certain combinations of
+        arguments.
 
         Note that this test does not test whether main.py catches the error raised by argparse."""
 
@@ -438,8 +445,13 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        with self.assertRaises(SystemExit):
-            args = parser.parse_args(("show", "hosts", "--format", "json", "--config", "this"))
+        mutex_args = ("--format json", "--config this", "--err", "--vars", "--verbose")
+
+        for combo in product(mutex_args, repeat=2):
+            cmd = ["show", "hosts"] + list(combo)
+
+            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                args = parser.parse_args(cmd)
 
     def test_hosts_subcommand_config_argument_nonexistant(self):
         """Test that the hosts subcommand --config argument does not raise an exception when
@@ -660,8 +672,8 @@ class ShowTests(unittest.PavTestCase):
         self.assertNotEqual(output, "", "pav show modes --config defaulted gave empty output")
 
     def test_modes_subcommand_config_mutual_exclusion(self):
-        """Test that the modes subcommand does not allow the --config and --format
-        arguments to be passed at the same time.
+        """Test that the modes subcommand correctly disallows certain combinations of
+        arguments.
 
         Note that this test does not test whether main.py catches the error raised by argparse."""
 
@@ -670,8 +682,13 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        with self.assertRaises(SystemExit):
-            args = parser.parse_args(("show", "modes", "--format", "json", "--config", "defaulted"))
+        mutex_args = ("--format json", "--config that", "--err", "--vars", "--verbose")
+
+        for combo in product(mutex_args, repeat=2):
+            cmd = ["show", "modes"] + list(combo)
+
+            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
+                args = parser.parse_args(cmd)
 
     def test_modes_subcommand_config_argument_nonexistant(self):
         """Test that the modes subcommand --config argument does not raise an exception when
@@ -1146,8 +1163,8 @@ class ShowTests(unittest.PavTestCase):
         self.assertNotEqual(error, "")
 
     def test_result_parsers_subcommand_mutual_exclusion(self):
-        """Test that the result_parsers subcommand does not allow the --doc and --format
-        arguments to be passed at the same time.
+        """Test that the platforms subcommand correctly disallows certain combinations of
+        arguments.
 
         Note that this test does not test whether main.py catches the error raised by argparse."""
 
@@ -1156,8 +1173,12 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        with self.assertRaises(SystemExit):
-            args = parser.parse_args(("show", "result_parsers", "--format", "json", "--doc", "regex"))
+        mutex_args = ("--format json", "--list", "--doc regex", "--verbose")
+
+        for combo in product(mutex_args, repeat=2):
+            cmd = ["show", "result_parsers"] + list(combo)
+
+            with self.assertRaises(SystemExit, msg=f"{' '.join(cmd)} did not correctly disallow the following combination of arguments: {combo}"):
 
      def test_result_parsers_subcommand_verbose_argument(self):
         """Test that the result_parsers subcommand --verbose argument behaves as expected."""

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -102,24 +102,26 @@ class ShowTests(unittest.PavTestCase):
             self.fail(f"pav show functions --detail nonexistant raised the following error:\n{err}")
 
     def test_functions_subcommand_format_argument(self):
-        """Test that the functions subcommand --format behaves as expected."""
+        """Test that the functions subcommand --format argument behaves as expected."""
 
         parser = arguments.get_parser()
 
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "functions", "--json"))
+        args = parser.parse_args(("show", "functions", "--format", "json"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show functions --json terminated with non-zero error code.')
+                         msg='pav show functions --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"JSON parsing failed for subcommand '{sub}'.\nOutput:\n{output}\n{e}")
+            self.fail(f"pav show functions --format json did not produce valid JSON. Output\n{output}")
 
-        self.assertIsInstance(data, list, f"Expected JSON list for '{sub}'.\nData:\n{data}")
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
     def test_functions_subcommand_mutual_exclusion(self):
         """Test that the functions subcommand does not allow the --detail and --format
@@ -130,10 +132,13 @@ class ShowTests(unittest.PavTestCase):
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        args = parser.parse_args(("show", "functions", "--json", "--detail", "int"))
+        try:
+            args = parser.parse_args(("show", "functions", "--format", "json", "--detail", "int"))
+        except SystemExit as err:
+            self.fail("pav show functions --format json --detail int produced the following error instead of terminating gracefully:\n{err}")
 
         self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show functions --json terminated with error code 0 despite bad combination of arguments.')
+                        msg='pav show functions --format json --detail int terminated with error code 0 despite bad combination of arguments.')
 
     def test_show_cmds(self):
 

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -19,6 +19,7 @@ class ShowTests(unittest.PavTestCase):
         show_cmd.silence()
 
         args = parser.parse_args(("show", "config"))
+
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show config terminated with non-zero error code.')
 
@@ -38,23 +39,105 @@ class ShowTests(unittest.PavTestCase):
         show_cmd.silence()
 
         args = parser.parse_args(("show", "config", "--template"))
+
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
                          msg='pav show config --template terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
         expected = io.StringIO()
-        config.PavilionConfigLoader().dump(expected, self.pav_cfg)
+        config.PavilionConfigLoader().dump(expected)
 
-        self.assertNotEqual(output, expected.getvalue(),
+        self.assertEqual(output, expected.getvalue(),
                          msg='Loaded Pavilion config was printed instead of the template.')
+
+    def test_functions_subcommand(self):
+        """Test that the functions subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "functions"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show functions terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show functions gave empty output")
+
+    def test_functions_subcommand_detail_argument(self):
+        """Test that the functions subcommand --detail argument works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "functions", "--detail", "int"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show functions terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show functions gave empty output")
+
+    def test_functions_subcommand_detail_argument_nonexistant(self):
+        """Test that the functions subcommand --detail argument does not raise an exception when
+        passed a non-existant function."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "functions", "--detail", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show functions terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show functions --detail nonexistant raised the following error:\n{err}")
+
+    def test_functions_subcommand_format_argument(self):
+        """Test that the functions subcommand --format behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "functions", "--json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show functions --json terminated with non-zero error code.')
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"JSON parsing failed for subcommand '{sub}'.\nOutput:\n{output}\n{e}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list for '{sub}'.\nData:\n{data}")
+
+    def test_functions_subcommand_mutual_exclusion(self):
+        """Test that the functions subcommand does not allow the --detail and --format
+        arguments to be passed at the same time."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "functions", "--json", "--detail", "int"))
+
+        self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show functions --json terminated with error code 0 despite bad combination of arguments.')
 
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'config'),
-            ('show', 'config', '--template'),
-            ('show', 'functions'),
-            ('show', 'functions', '--detail', 'int'),
             ('show', 'platform'),
             ('show', 'platform', '--verbose'),
             ('show', 'platform', '--vars', 'that'),

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -63,6 +63,7 @@ class ShowTests(unittest.PavTestCase):
 
     def test_show_format_json(self):
         """Iterate over all show sub‑commands and verify JSON output."""
+
         subcommands = [
             'config', 'config_dirs', 'collections', 'functions',
             'platform', 'hosts', 'modes', 'module_wrappers',
@@ -74,19 +75,73 @@ class ShowTests(unittest.PavTestCase):
         parser = arguments.get_parser()
         show_cmd = commands.get_command('show')
         show_cmd.silence()
+
         # Capture output
         show_cmd.outfile = io.StringIO()
 
         for sub in subcommands:
             args = parser.parse_args(['show', sub, '--format', 'json'])
             ret = show_cmd.run(self.pav_cfg, args)
+
             self.assertEqual(ret, 0)
+
             output = show_cmd.outfile.getvalue()
+
             try:
                 data = json.loads(output)
             except Exception as e:
                 self.fail(f"JSON parsing failed for subcommand '{sub}': {e}")
+
             self.assertIsInstance(data, list, f"Expected JSON list for '{sub}'")
+
             # Reset for next iteration
+            show_cmd.outfile.truncate(0)
+            show_cmd.outfile.seek(0)
+
+    def test_show_format_table(self):
+        """Iterate over all show sub‑commands and verify table output."""
+        subcommands = [
+            'config', 'config_dirs', 'collections', 'functions',
+            'platform', 'hosts', 'modes', 'module_wrappers',
+            'pav_vars', 'result_parsers', 'result_base',
+            'schedulers', 'states', 'sys_vars', 'suites',
+            'tests', 'series', 'test_config'
+        ]
+
+        parser = arguments.get_parser()
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+        show_cmd.outfile = io.StringIO()
+
+        for sub in subcommands:
+            args = parser.parse_args(['show', sub, '--format', 'table'])
+            ret = show_cmd.run(self.pav_cfg, args)
+            self.assertEqual(ret, 0)
+            output = show_cmd.outfile.getvalue()
+            self.assertTrue(output.strip(), f"Expected non-empty table output for '{sub}'")
+            show_cmd.outfile.truncate(0)
+            show_cmd.outfile.seek(0)
+
+    def test_show_format_list(self):
+        """Iterate over all show sub‑commands and verify list output."""
+        subcommands = [
+            'config', 'config_dirs', 'collections', 'functions',
+            'platform', 'hosts', 'modes', 'module_wrappers',
+            'pav_vars', 'result_parsers', 'result_base',
+            'schedulers', 'states', 'sys_vars', 'suites',
+            'tests', 'series', 'test_config'
+        ]
+
+        parser = arguments.get_parser()
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+        show_cmd.outfile = io.StringIO()
+
+        for sub in subcommands:
+            args = parser.parse_args(['show', sub, '--format', 'list'])
+            ret = show_cmd.run(self.pav_cfg, args)
+            self.assertEqual(ret, 0)
+            output = show_cmd.outfile.getvalue()
+            self.assertTrue(output.strip(), f"Expected non-empty list output for '{sub}'")
             show_cmd.outfile.truncate(0)
             show_cmd.outfile.seek(0)

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -101,6 +101,10 @@ class ShowTests(unittest.PavTestCase):
         except Exception as err:
             self.fail(f"pav show functions --detail nonexistant raised the following error:\n{err}")
 
+        # Check that an error was printed to standard output
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
     def test_functions_subcommand_format_argument(self):
         """Test that the functions subcommand --format argument behaves as expected."""
 
@@ -125,20 +129,17 @@ class ShowTests(unittest.PavTestCase):
 
     def test_functions_subcommand_mutual_exclusion(self):
         """Test that the functions subcommand does not allow the --detail and --format
-        arguments to be passed at the same time."""
+        arguments to be passed at the same time.
+
+        Note that this test does not test whether main.py catches the error raised by argparse."""
 
         parser = arguments.get_parser()
 
         show_cmd = commands.get_command('show')
         show_cmd.silence()
 
-        try:
+        with self.assertRaises(SystemExit):
             args = parser.parse_args(("show", "functions", "--format", "json", "--detail", "int"))
-        except SystemExit as err:
-            self.fail("pav show functions --format json --detail int produced the following error instead of terminating gracefully:\n{err}")
-
-        self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
-                        msg='pav show functions --format json --detail int terminated with error code 0 despite bad combination of arguments.')
 
     def test_show_cmds(self):
 

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -1,12 +1,52 @@
+import io
+import json
+
 from pavilion import unittest
 from pavilion import arguments
 from pavilion import plugins
 from pavilion import commands
-import io
-import json
+from pavilion import config
 
 
 class ShowTests(unittest.PavTestCase):
+
+    def test_config_subcommand(self):
+        """Test that the config subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "config"))
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show config terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+        expected = io.StringIO()
+        config.PavilionConfigLoader().dump(expected, self.pav_cfg)
+
+        self.assertEqual(output, expected.getvalue(),
+                         msg='pav show config output does not match loaded Pavilion config.')
+
+    def test_config_subcommand_template_arg(self):
+        """Test that the config subcommand --template argument works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "config", "--template"))
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show config --template terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+        expected = io.StringIO()
+        config.PavilionConfigLoader().dump(expected, self.pav_cfg)
+
+        self.assertNotEqual(output, expected.getvalue(),
+                         msg='Loaded Pavilion config was printed instead of the template.')
 
     def test_show_cmds(self):
 

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -141,11 +141,122 @@ class ShowTests(unittest.PavTestCase):
         with self.assertRaises(SystemExit):
             args = parser.parse_args(("show", "functions", "--format", "json", "--detail", "int"))
 
+    def test_platforms_subcommand(self):
+        """Test that the platforms subcommand, with no arguments, works as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show functions terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show platforms gave empty output")
+
+    def test_platforms_subcommand_format_argument(self):
+        """Test that the platforms subcommand --format argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
+                         msg='pav show platforms --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show platforms --format json did not produce valid JSON. Output\n{output}")
+
+    def test_platforms_subcommand_mutual_exclusion(self):
+        """Test that the platforms subcommand does not allow the --config and --format
+        arguments to be passed at the same time.
+
+        Note that this test does not test whether main.py catches the error raised by argparse."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        with self.assertRaises(SystemExit):
+            args = parser.parse_args(("show", "platforms", "--format", "json", "--config", "cos-3"))
+
+    def test_platforms_subcommand_config_argument_nonexistant(self):
+        """Test that the platforms subcommand --config argument does not raise an exception when
+        passed a non-existant platform."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--config", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show platforms terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show platforms --config nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard output
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_platforms_subcommand_verbose_argument(self):
+        """Test that the platforms subcommand --verbose argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--verbose"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show platforms --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show platforms --verbose gave empty output")
+
+    def test_platforms_subcommand_verbose_format(self):
+        """Test that the platforms subcommand --verbose argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--verbose", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show platforms --verbose terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show platforms --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'platform'),
-            ('show', 'platform', '--verbose'),
             ('show', 'platform', '--vars', 'that'),
             ('show', 'platform', '--config', 'that'),
             ('show', 'hosts'),
@@ -242,13 +353,6 @@ class ShowTests(unittest.PavTestCase):
 
     def test_show_format_list(self):
         """Iterate over all show sub‑commands and verify list output."""
-        subcommands = [
-            'config', 'config_dirs', 'collections', 'functions',
-            'platform', 'hosts', 'modes', 'module_wrappers',
-            'pav_vars', 'result_parsers', 'result_base',
-            'schedulers', 'states', 'sys_vars', 'suites',
-            'tests', 'series', 'test_config'
-        ]
 
         parser = arguments.get_parser()
         show_cmd = commands.get_command('show')

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -2,6 +2,8 @@ from pavilion import unittest
 from pavilion import arguments
 from pavilion import plugins
 from pavilion import commands
+import io
+import json
 
 
 class ShowTests(unittest.PavTestCase):
@@ -58,3 +60,33 @@ class ShowTests(unittest.PavTestCase):
         for arg_list in arg_lists:
             args = parser.parse_args(arg_list)
             self.assertEqual(show_cmd.run(self.pav_cfg, args), 0)
+
+    def test_show_format_json(self):
+        """Iterate over all show sub‑commands and verify JSON output."""
+        subcommands = [
+            'config', 'config_dirs', 'collections', 'functions',
+            'platform', 'hosts', 'modes', 'module_wrappers',
+            'pav_vars', 'result_parsers', 'result_base',
+            'schedulers', 'states', 'sys_vars', 'suites',
+            'tests', 'series', 'test_config'
+        ]
+
+        parser = arguments.get_parser()
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+        # Capture output
+        show_cmd.outfile = io.StringIO()
+
+        for sub in subcommands:
+            args = parser.parse_args(['show', sub, '--format', 'json'])
+            ret = show_cmd.run(self.pav_cfg, args)
+            self.assertEqual(ret, 0)
+            output = show_cmd.outfile.getvalue()
+            try:
+                data = json.loads(output)
+            except Exception as e:
+                self.fail(f"JSON parsing failed for subcommand '{sub}': {e}")
+            self.assertIsInstance(data, list, f"Expected JSON list for '{sub}'")
+            # Reset for next iteration
+            show_cmd.outfile.truncate(0)
+            show_cmd.outfile.seek(0)

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -101,7 +101,7 @@ class ShowTests(unittest.PavTestCase):
         except Exception as err:
             self.fail(f"pav show functions --detail nonexistant raised the following error:\n{err}")
 
-        # Check that an error was printed to standard output
+        # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
         self.assertNotEqual(error, "")
 
@@ -222,11 +222,11 @@ class ShowTests(unittest.PavTestCase):
 
         try:
             self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
-                            msg='pav show platforms terminated with error code 0 despite bad input.')
+                            msg='pav show platforms --config nonexistant terminated with error code 0 despite bad input.')
         except Exception as err:
             self.fail(f"pav show platforms --config nonexistant raised the following error:\n{err}")
 
-        # Check that an error was printed to standard output
+        # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
         self.assertNotEqual(error, "")
 
@@ -346,7 +346,7 @@ class ShowTests(unittest.PavTestCase):
         except Exception as err:
             self.fail(f"pav show platforms --vars nonexistant raised the following error:\n{err}")
 
-        # Check that an error was printed to standard output
+        # Check that an error was printed to standard error
         error = show_cmd.errfile.getvalue()
         self.assertNotEqual(error, "")
 

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -61,16 +61,12 @@ class ShowTests(unittest.PavTestCase):
             args = parser.parse_args(arg_list)
             self.assertEqual(show_cmd.run(self.pav_cfg, args), 0)
 
+    FORMATTABLE_SUBCMDS = ('config_dirs', 'collections', 'functions', 'platform', 'hosts', 'modes',
+                        'module_wrappers', 'pav_vars', 'result_parsers', 'result_base',
+                        'scheduler', 'states', 'sys_vars', 'suites', 'tests', 'series')
+
     def test_show_format_json(self):
         """Iterate over all show sub‑commands and verify JSON output."""
-
-        subcommands = [
-            'config', 'config_dirs', 'collections', 'functions',
-            'platform', 'hosts', 'modes', 'module_wrappers',
-            'pav_vars', 'result_parsers', 'result_base',
-            'schedulers', 'states', 'sys_vars', 'suites',
-            'tests', 'series', 'test_config'
-        ]
 
         parser = arguments.get_parser()
         show_cmd = commands.get_command('show')
@@ -79,7 +75,7 @@ class ShowTests(unittest.PavTestCase):
         # Capture output
         show_cmd.outfile = io.StringIO()
 
-        for sub in subcommands:
+        for sub in self.FORMATTABLE_SUBCMDS:
             args = parser.parse_args(['show', sub, '--format', 'json'])
             ret = show_cmd.run(self.pav_cfg, args)
 
@@ -90,9 +86,9 @@ class ShowTests(unittest.PavTestCase):
             try:
                 data = json.loads(output)
             except Exception as e:
-                self.fail(f"JSON parsing failed for subcommand '{sub}': {e}")
+                self.fail(f"JSON parsing failed for subcommand '{sub}'.\nOutput:\n{output}\n{e}")
 
-            self.assertIsInstance(data, list, f"Expected JSON list for '{sub}'")
+            self.assertIsInstance(data, list, f"Expected JSON list for '{sub}'.\nData:\n{data}")
 
             # Reset for next iteration
             show_cmd.outfile.truncate(0)
@@ -100,20 +96,13 @@ class ShowTests(unittest.PavTestCase):
 
     def test_show_format_table(self):
         """Iterate over all show sub‑commands and verify table output."""
-        subcommands = [
-            'config', 'config_dirs', 'collections', 'functions',
-            'platform', 'hosts', 'modes', 'module_wrappers',
-            'pav_vars', 'result_parsers', 'result_base',
-            'schedulers', 'states', 'sys_vars', 'suites',
-            'tests', 'series', 'test_config'
-        ]
 
         parser = arguments.get_parser()
         show_cmd = commands.get_command('show')
         show_cmd.silence()
         show_cmd.outfile = io.StringIO()
 
-        for sub in subcommands:
+        for sub in self.FORMATTABLE_SUBCMDS:
             args = parser.parse_args(['show', sub, '--format', 'table'])
             ret = show_cmd.run(self.pav_cfg, args)
             self.assertEqual(ret, 0)
@@ -137,7 +126,7 @@ class ShowTests(unittest.PavTestCase):
         show_cmd.silence()
         show_cmd.outfile = io.StringIO()
 
-        for sub in subcommands:
+        for sub in self.FORMATTABLE_SUBCMDS:
             args = parser.parse_args(['show', sub, '--format', 'list'])
             ret = show_cmd.run(self.pav_cfg, args)
             self.assertEqual(ret, 0)

--- a/test/tests/show_tests.py
+++ b/test/tests/show_tests.py
@@ -78,11 +78,11 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "functions", "--detail", "int"))
 
         self.assertEqual(show_cmd.run(self.pav_cfg, args), 0,
-                         msg='pav show functions terminated with non-zero error code.')
+                         msg='pav show functions --detail int terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
-        self.assertNotEqual(output, "", "pav show functions gave empty output")
+        self.assertNotEqual(output, "", "pav show functions --detail int gave empty output")
 
     def test_functions_subcommand_detail_argument_nonexistant(self):
         """Test that the functions subcommand --detail argument does not raise an exception when
@@ -97,7 +97,7 @@ class ShowTests(unittest.PavTestCase):
 
         try:
             self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
-                            msg='pav show functions terminated with error code 0 despite bad input.')
+                            msg='pav show functions --detail nonexistant terminated with error code 0 despite bad input.')
         except Exception as err:
             self.fail(f"pav show functions --detail nonexistant raised the following error:\n{err}")
 
@@ -152,7 +152,7 @@ class ShowTests(unittest.PavTestCase):
         args = parser.parse_args(("show", "platforms"))
 
         self.assertEqual(show_cmd.run(self.platforms, args), 0,
-                         msg='pav show functions terminated with non-zero error code.')
+                         msg='pav show platforms terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
@@ -178,7 +178,24 @@ class ShowTests(unittest.PavTestCase):
         except Exception as e:
             self.fail(f"pav show platforms --format json did not produce valid JSON. Output\n{output}")
 
-    def test_platforms_subcommand_mutual_exclusion(self):
+    def test_platforms_subcommand_config_argument(self):
+        """Test that the platforms subcommand works as expected when the --config argument is passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--config", "that"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show platforms --config that terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show platforms --config that gave empty output")
+
+    def test_platforms_subcommand_config_mutual_exclusion(self):
         """Test that the platforms subcommand does not allow the --config and --format
         arguments to be passed at the same time.
 
@@ -190,7 +207,7 @@ class ShowTests(unittest.PavTestCase):
         show_cmd.silence()
 
         with self.assertRaises(SystemExit):
-            args = parser.parse_args(("show", "platforms", "--format", "json", "--config", "cos-3"))
+            args = parser.parse_args(("show", "platforms", "--format", "json", "--config", "that"))
 
     def test_platforms_subcommand_config_argument_nonexistant(self):
         """Test that the platforms subcommand --config argument does not raise an exception when
@@ -243,22 +260,122 @@ class ShowTests(unittest.PavTestCase):
 
 
         self.assertEqual(show_cmd.run(self.platforms, args), 0,
-                         msg='pav show platforms --verbose terminated with non-zero error code.')
+                         msg='pav show platforms --verbose --format json terminated with non-zero error code.')
 
         output = show_cmd.outfile.getvalue()
 
         try:
             data = json.loads(output)
         except Exception as e:
-            self.fail(f"pav show platforms --format json did not produce valid JSON. Output\n{output}")
+            self.fail(f"pav show platforms --verbose --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_platforms_subcommand_err_argument(self):
+        """Test that the platforms subcommand --err argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--err"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show platforms --err terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show platforms --err gave empty output")
+
+    def test_platforms_subcommand_err_format(self):
+        """Test that the platforms subcommand --err argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--err", "--format", "json"))
+
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show platforms --err --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show platforms --err --format json did not produce valid JSON. Output\n{output}")
+
+        self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
+
+    def test_platforms_subcommand_vars_argument(self):
+        """Test that the platforms subcommand --vars argument behaves as expected."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--vars", "that"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show platforms --vars that terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        self.assertNotEqual(output, "", "pav show platforms --vars that gave empty output")
+
+    def test_platforms_subcommand_vars_argument_nonexistant(self):
+        """Test that the platforms subcommand --vars argument does not raise an exception when
+        passed a non-existant platform."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--vars", "nonexistant"))
+
+        try:
+            self.assertNotEqual(show_cmd.run(self.pav_cfg, args), 0,
+                            msg='pav show platforms --vars nonexistant terminated with error code 0 despite bad input.')
+        except Exception as err:
+            self.fail(f"pav show platforms --vars nonexistant raised the following error:\n{err}")
+
+        # Check that an error was printed to standard output
+        error = show_cmd.errfile.getvalue()
+        self.assertNotEqual(error, "")
+
+    def test_platforms_subcommand_vars_format(self):
+        """Test that the platforms subcommand --vars argument behaves as expected when the
+        --format argument is also passed."""
+
+        parser = arguments.get_parser()
+
+        show_cmd = commands.get_command('show')
+        show_cmd.silence()
+
+        args = parser.parse_args(("show", "platforms", "--vars", "that", "--format", "json"))
+
+        self.assertEqual(show_cmd.run(self.platforms, args), 0,
+                         msg='pav show platforms --vars that --format json terminated with non-zero error code.')
+
+        output = show_cmd.outfile.getvalue()
+
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            self.fail(f"pav show platforms --vars that --format json did not produce valid JSON. Output\n{output}")
 
         self.assertIsInstance(data, list, f"Expected JSON list.\nReceived:\n{data}")
 
     def test_show_cmds(self):
 
         arg_lists = [
-            ('show', 'platform', '--vars', 'that'),
-            ('show', 'platform', '--config', 'that'),
             ('show', 'hosts'),
             ('show', 'hosts', '--verbose'),
             ('show', 'hosts', '--vars', 'this'),


### PR DESCRIPTION
Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
