### PR TITLE
Fix inconsistent shebang defaults

### DIFF
--- a/lib/pavilion/scriptcomposer.py
+++ b/lib/pavilion/scriptcomposer.py
@@ -17,10 +17,10 @@ class ScriptComposerError(RuntimeError):
 class ScriptHeader:
     """Class to serve as a struct for the script header."""
 
-    def __init__(self, shebang='#!/bin/bash'):
+    def __init__(self, shebang='#!/usr/bin/bash'):
         """The header values for a script.
         :param string shebang: Shell path specification.  Typically
-                                  '/bin/bash'.  default = None.
+                                  '/bin/bash'.  default = '#!/usr/bin/bash'.
         """
 
         # Set _shebang so that style_check doesn't complain at the setter block.
@@ -61,7 +61,7 @@ class ScriptComposer:
         the variables.
 
         :param ScriptHeader header: The header class to use. Defaults to one
-            that simply adds ``#!/bin/bash`` as the file header.
+            that simply adds ``#!/usr/bin/bash`` as the file header.
         """
 
         if header is None:

--- a/test/tests/scriptComposer_tests.py
+++ b/test/tests/scriptComposer_tests.py
@@ -50,7 +50,7 @@ class TestScriptWriter(PavTestCase):
         # Testing initialization defaults.
         composer = scriptcomposer.ScriptComposer()
 
-        self.assertEqual(composer.header.shebang, '#!/bin/bash')
+        self.assertEqual(composer.header.shebang, '#!/usr/bin/bash')
 
         # Testing individual assignment
         test_header_shell = "/usr/env/python"
@@ -67,7 +67,7 @@ class TestScriptWriter(PavTestCase):
 
         composer = scriptcomposer.ScriptComposer()
 
-        self.assertEqual(composer.header.shebang, '#!/bin/bash')
+        self.assertEqual(composer.header.shebang, '#!/usr/bin/bash')
 
         # Testing object assignment.
         header = scriptcomposer.ScriptHeader(


### PR DESCRIPTION
Fixed default `shebang` value for `ScriptComposer` to be consistent with the test config default.

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
