### PR TITLE
Rewrite `test_owner` unit test not to use privilege escalation

### DIFF
--- a/test/tests/cancel_tests.py
+++ b/test/tests/cancel_tests.py
@@ -32,7 +32,7 @@ class CancelTests(unittest.PavTestCase):
         wait(lambda: test2.status.has_state(STATES.RUNNING), interval=0.2, timeout=10)
 
         jobs = cancel_utils.cancel_jobs(self.pav_cfg, [test1, test2])
-        self.assertEqual(test2.status.current().state, STATES.RUNNING)
+        self.assertEqual(test2.status.current().state, STATES.RUNNINGm msg=f"Test {test2.id} does not have state 'RUNNING'.")
         self.assertTrue(test1.cancelled)
         self.assertFalse(jobs[0]['success'])
 

--- a/test/tests/cancel_tests.py
+++ b/test/tests/cancel_tests.py
@@ -32,7 +32,7 @@ class CancelTests(unittest.PavTestCase):
         wait(lambda: test2.status.has_state(STATES.RUNNING), interval=0.2, timeout=10)
 
         jobs = cancel_utils.cancel_jobs(self.pav_cfg, [test1, test2])
-        self.assertEqual(test2.status.current().state, STATES.RUNNINGm msg=f"Test {test2.id} does not have state 'RUNNING'.")
+        self.assertEqual(test2.status.current().state, STATES.RUNNING, msg=f"Test {test2.id} does not have state 'RUNNING'.")
         self.assertTrue(test1.cancelled)
         self.assertFalse(jobs[0]['success'])
 

--- a/test/tests/utils_tests.py
+++ b/test/tests/utils_tests.py
@@ -6,10 +6,18 @@ import getpass
 import os
 import tempfile
 from pathlib import Path
+import unittest
+import shutil
 
 from pavilion import unittest
 from pavilion import utils
 from pavilion.cmd_utils import list_files
+
+
+def is_privileged() -> bool:
+    """Check if the current process can perform privileged actions."""
+
+    return shutil.which("sudo") is not None or os.geteuid() == 0
 
 
 class UtilsTests(unittest.PavTestCase):
@@ -55,8 +63,11 @@ class UtilsTests(unittest.PavTestCase):
             with self.assertRaises(ValueError):
                 utils.hr_cutoff_to_ts(example)
 
+    @unittest.skipIf(not is_privileged(), "Process cannot perform privileged actions.")
     def test_owner(self):
         """Check that the owner function works."""
+
+        # TODO: Re-write this test not to rely on privilege escalation.
 
         path = Path(tempfile.mktemp())
 

--- a/test/tests/utils_tests.py
+++ b/test/tests/utils_tests.py
@@ -5,30 +5,14 @@ import subprocess as sp
 import getpass
 import os
 import tempfile
+import pwd
 from pathlib import Path
-import unittest
-import shutil
+from unittest import mock
+from types import SimpleNamespace
 
 from pavilion import utils
 from pavilion.cmd_utils import list_files
 from pavilion.unittest import PavTestCase
-
-
-def is_privileged() -> bool:
-    """Check if the current process can perform privileged actions."""
-
-    if os.geteuid() == 0:
-        return True
-    if shutil.which("sudo") is None:
-        return False
-
-    result = sp.run(
-        ["sudo", "-n", "true"],
-        stdout=sp.DEVNULL,
-        stderr=sp.DEVNULL,
-    )
-
-    return result.returncode == 0
 
 
 class UtilsTests(PavTestCase):
@@ -74,7 +58,6 @@ class UtilsTests(PavTestCase):
             with self.assertRaises(ValueError):
                 utils.hr_cutoff_to_ts(example)
 
-    @unittest.skipIf(not is_privileged(), "Process cannot perform privileged actions.")
     def test_owner(self):
         """Check that the owner function works."""
 
@@ -87,13 +70,10 @@ class UtilsTests(PavTestCase):
 
         self.assertEqual(utils.owner(path), getpass.getuser())
 
-        # Try to set the permissions of the file to an unknown user.
-        proc = sp.Popen(['sudo', '-n', 'chown', '12341', path.as_posix(), '||',
-                            'chown', '12341', path.as_posix()],
-                            stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)
-
-        if proc.wait(5) == 0:
-            self.assertEqual(utils.owner(path), "<unknown user '12341'>")
+        # Simulate a file owned by a UID that has no corresponding user entry
+        with mock.patch.object(Path, "stat", return_value=SimpleNamespace(st_uid=12341)):
+            with mock.patch.object(pwd, "getpwuid", side_effect=KeyError):
+                self.assertEqual(utils.owner(path), "<unknown user '12341'>")
 
     def test_relative_to(self):
         """Check relative path calculations."""

--- a/test/tests/utils_tests.py
+++ b/test/tests/utils_tests.py
@@ -61,8 +61,6 @@ class UtilsTests(PavTestCase):
     def test_owner(self):
         """Check that the owner function works."""
 
-        # TODO: Re-write this test not to rely on privilege escalation.
-
         path = Path(tempfile.mktemp())
 
         with path.open('w') as file:

--- a/test/tests/utils_tests.py
+++ b/test/tests/utils_tests.py
@@ -9,9 +9,9 @@ from pathlib import Path
 import unittest
 import shutil
 
-from pavilion import unittest
 from pavilion import utils
 from pavilion.cmd_utils import list_files
+from pavilion.unittest import PavTestCase
 
 
 def is_privileged() -> bool:
@@ -31,7 +31,7 @@ def is_privileged() -> bool:
     return result.returncode == 0
 
 
-class UtilsTests(unittest.PavTestCase):
+class UtilsTests(PavTestCase):
 
     def test_hr_cutoff(self):
         """Check hr_cutoff_to_datetime function."""

--- a/test/tests/utils_tests.py
+++ b/test/tests/utils_tests.py
@@ -17,7 +17,18 @@ from pavilion.cmd_utils import list_files
 def is_privileged() -> bool:
     """Check if the current process can perform privileged actions."""
 
-    return shutil.which("sudo") is not None or os.geteuid() == 0
+    if os.geteuid() == 0:
+        return True
+    if shutil.which("sudo") is None:
+        return False
+
+    result = sp.run(
+        ["sudo", "-n", "true"],
+        stdout=sp.DEVNULL,
+        stderr=sp.DEVNULL,
+    )
+
+    return result.returncode == 0
 
 
 class UtilsTests(unittest.PavTestCase):
@@ -77,8 +88,10 @@ class UtilsTests(unittest.PavTestCase):
         self.assertEqual(utils.owner(path), getpass.getuser())
 
         # Try to set the permissions of the file to an unknown user.
-        proc = sp.Popen(['sudo', '-n', 'chown', '12341', path.as_posix()],
-                        stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)
+        proc = sp.Popen(['sudo', '-n', 'chown', '12341', path.as_posix(), '||',
+                            'chown', '12341', path.as_posix()],
+                            stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)
+
         if proc.wait(5) == 0:
             self.assertEqual(utils.owner(path), "<unknown user '12341'>")
 


### PR DESCRIPTION
Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
