### PR TITLE
Fix `test_ex_path_elem` when `$USER` is not defined

### DIFF
--- a/test/tests/pav_config_tests.py
+++ b/test/tests/pav_config_tests.py
@@ -41,8 +41,10 @@ class PavConfigTests(PavTestCase):
 
         elem = config.ExPathElem("test")
 
+        os.environ['PATH_VAR'] = "foo"
+
         self.assertIsNone(elem.validate(None))
-        self.assertEqual(elem.validate("/tmp/$USER/blarg"),
-                         Path('/tmp', os.environ['USER'], 'blarg'))
+        self.assertEqual(elem.validate("/tmp/$PATH_VAR/blarg"),
+                         Path('/tmp', os.environ['PATH_VAR'], 'blarg'))
         self.assertEqual(elem.validate("/tmp/${NO_SUCH_VAR}/ok"),
                          Path("/tmp/${NO_SUCH_VAR}/ok"))


### PR DESCRIPTION
Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
