### PR TITLE
Fix spack TTY error and orphaned processes

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -9,6 +9,10 @@ RELEASE=2.6
   configuration directories were used.
 - Fixed a bug in which the wrong suite was sometimes loaded when suites with the same name existed
   in different config directories.
+- Fixed a bug that caused the build and run commands to sometimes leave behind orphan processes
+  on timeout or cancellation.
+- Fixed a bug that that caused Spack to issue a traceback due to running in a non-interactive
+  context.
 
 ## 2.6 Release Notes
 

--- a/lib/pavilion/builder.py
+++ b/lib/pavilion/builder.py
@@ -13,6 +13,7 @@ import subprocess
 import tarfile
 import threading
 import time
+import signal
 import urllib.parse
 from pathlib import Path
 from typing import Union, Dict, Optional, List, IO
@@ -596,8 +597,10 @@ class TestBuilder:
 
                 proc = subprocess.Popen(cmd,
                                         cwd=build_dir.as_posix(),
+                                        preexec_fn=os.setsid,
                                         stdout=build_log,
-                                        stderr=build_log)
+                                        stderr=build_log,
+                                        stdin=subprocess.DEVNULL)
 
                 result = None
                 timeout = time.time() + self._timeout
@@ -620,7 +623,7 @@ class TestBuilder:
                         # Has the output file changed recently?
                         if time.time() > timeout:
                             # Give up on the build, and call it a failure.
-                            proc.kill()
+                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                             tracker.fail(
                                 state=STATES.BUILD_TIMEOUT,
                                 note="Build timed out after {} seconds."
@@ -628,7 +631,7 @@ class TestBuilder:
                             return False
 
                         if cancel_event is not None and cancel_event.is_set():
-                            proc.kill()
+                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                             tracker.update(
                                 state=STATES.ABORTED,
                                 note="Build canceled due to other builds "

--- a/lib/pavilion/test_run/test_run.py
+++ b/lib/pavilion/test_run/test_run.py
@@ -15,6 +15,7 @@ import threading
 import time
 import uuid
 import os
+import signal
 from pathlib import Path
 from typing import Any, TextIO, Union, Dict, Optional, List
 import yc_yaml as yaml
@@ -741,8 +742,10 @@ class TestRun(TestAttributes):
             cmd = [self.run_script_path.as_posix(), str(self.id)]
             proc = subprocess.Popen(cmd,
                                     cwd=run_wd,
+                                    preexec_fn=os.setsid,
                                     stdout=run_log,
-                                    stderr=subprocess.STDOUT)
+                                    stderr=subprocess.STDOUT,
+                                    stdin=subprocess.DEVNULL)
 
             self.status.set(STATES.RUNNING,
                             "Currently running.")
@@ -773,7 +776,7 @@ class TestRun(TestAttributes):
                     if self.run_timeout is not None:
                         if self.run_timeout < quiet_time:
                             # Give up on the build, and call it a failure.
-                            proc.kill()
+                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                             msg = ("Run timed out after {} seconds"
                                    .format(self.run_timeout))
                             self.status.set(STATES.RUN_TIMEOUT, msg)
@@ -781,7 +784,7 @@ class TestRun(TestAttributes):
                             self.save_attributes()
                             raise TimeoutError(msg)
                         elif self.cancelled:
-                            proc.kill()
+                            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                             self.status.set(
                                 STATES.SCHED_CANCELLED,
                                 "Test cancelled mid-run.")

--- a/test/tests/spack_tests.py
+++ b/test/tests/spack_tests.py
@@ -33,6 +33,7 @@ class SpackTests(PavTestCase):
             'install': 'time',
             'load': 'time',
         }
+        cfg["build"]["timeout"] = 60
         cfg['run']['spack'] = {
             'load': 'time'
         }


### PR DESCRIPTION
These changes fix a pair of bugs:

1. The `build` and `run` methods would leave behind orphaned processes when killing subprocesses, if those subprocesses had themselves started their own subprocesses.

2. When building with Spack, Spack would issue a traceback complaining that it could not perform TTY-related operations.