### PR TITLE
Fix `null` result in results log

### DIFF
--- a/lib/pavilion/series/series.py
+++ b/lib/pavilion/series/series.py
@@ -587,7 +587,7 @@ class TestSeries:
             for test in all_tests:
                 state = get_status(test, self.pav_cfg).get("state", STATES.UNKNOWN)
 
-                if state == STATES.COMPLETE:
+                if test.complete:
                     output.fprint(self.outfile,
                                 f"Test {test.id} has completed. Logging results...")
 


### PR DESCRIPTION
This commit fixes a race condition in which result loggers sometimes read `results.json` before it has been fully written, resulting in `null` results and missing keys in the result log.