### PR TITLE
Fix intermittent failure in result logger unit test

### DIFF
--- a/test/tests/result_logger_tests.py
+++ b/test/tests/result_logger_tests.py
@@ -466,6 +466,11 @@ class ResultLoggerTests(PavTestCase):
         except TimeoutError:
             self.fail(f"Timed out waiting for series {last_series.id} to complete after 10 seconds.")
 
+        try:
+            last_series.wait_log(timeout=10)
+        except TimeoutError:
+            self.fail(f"Timed out waiting for series {last_series.id} to finish logging results after 10 seconds.")
+
         matches = list(reused_series_results_dir.glob(f"{last_series.id}*"))
 
         self.assertEqual(len(matches), 2,


### PR DESCRIPTION
The reused-series test waited for series completion before checking the results directory, but it did not wait for asynchronous result logging to finish. This could allow the directory to be inspected before the second log file had been written.

Wait for result logging to complete before verifying that two distinct log files exist for the reused series ID.

Provenance: ChatGPT (GPT-5.5 Instant, OpenAI)
Workflow: consulted

Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
