### PR TITLE
Fix omitted `-w` option when using `across_nodes`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ __pycache__/
 pav.pstats
 .local/
 examples/working_dir
+
+# Agentic Coding Artifacts
+.agents
+.chunkhound
+.codebase-memory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   they had been fully written, resulting in `null` results and missing keys in the result log.
 - Fixed an issue that caused tests to be incorrectly scheduled on overlapping sets of nodes when
   using chunking.
+- Fixed a bug that generated an incorrect kickoff script under certain conditions when `across_nodes` was specified.
+  When `across_nodes` was specified, generated kickoff scripts for tests that did not use chunking and did not share an allocation with other tests would incorrectly omit Slurm's `-w` flag.
 
 ### Changed
 

--- a/lib/pavilion/schedulers/advanced.py
+++ b/lib/pavilion/schedulers/advanced.py
@@ -600,7 +600,7 @@ class SchedulerPluginAdvanced(SchedulerPlugin, ABC):
 
             node_range = calc_node_range(sched_config, len(chunk))
 
-            script = self.create_kickoff_script(pav_cfg, test, job.kickoff_log)
+            script = self.create_kickoff_script(pav_cfg, test, job.kickoff_log, nodes=chunk)
             script.write(job.kickoff_path)
 
             test.job = job


### PR DESCRIPTION
Code review checklist:

- [ ] Code is generally sensical and well commented
- [ ] Variable/function names all telegraph their purpose and contents
- [ ] Functions/classes have useful doc strings
- [ ] Function arguments are typed
- [ ] Added/modified unit tests to cover changes.
- [ ] New features have documentation added to the docs.
- [ ] New features and backwards compatibility breaks are noted in the RELEASE.md
