### PR TITLE
Add PBS scheduler plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a `--format` flag to `pav show`, which allows presentation of output as a list, table,
 or JSON.
+- Added a scheduler plugin for the PBS scheduler.
 
 ### 2.6.2
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -5,6 +5,9 @@ RELEASE=2.6
 ## 2.7 Pre-Release Notes
   - Added a `--format` flag to `pav show`, which allows presentation of output as a list, table,
     or JSON.
+  - Added a scheduler plugin for the PBS scheduler.
+
+# Release History
 
 ## 2.6 Release Notes
 
@@ -27,8 +30,6 @@ RELEASE=2.6
   sbatch scripts.
 - Various minor bug mixes.
 - Minor documentation edits.
-
-# Release History
 
 ## 2.5 Release Notes
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -3,6 +3,7 @@
 RELEASE=2.6
 
 ## 2.7 Pre-Release Notes
+
   - Added a `--format` flag to `pav show`, which allows presentation of output as a list, table,
     or JSON.
   - Added a scheduler plugin for the PBS scheduler.

--- a/docs/tests/scheduling.rst
+++ b/docs/tests/scheduling.rst
@@ -24,6 +24,92 @@ Pavilion comes with three scheduler plugins:
      raw       | Schedules tests as local processes.
      slurm     | Schedules tests via the Slurm scheduler.
      flux      | Schedules tests via the Flux Framework scheduler.
+     pbs       | Schedules tests via the PBS scheduler.
+
+PBS
+~~~
+
+The ``pbs`` scheduler submits each job with ``qsub``. Its scheduler specific
+options go in the ``pbs`` section under ``schedule``:
+
+.. code-block:: yaml
+
+    pbs_test:
+      scheduler: pbs
+
+      schedule:
+        nodes: 2
+
+        pbs:
+          queue: workq
+          walltime: '00:10:00'
+          tasks: 4
+
+Options
+^^^^^^^
+
+Use ``pav show sched --conf`` for the authoritative list. The PBS specific
+options are:
+
+``queue``
+    The queue (``qsub -q``) to submit to. When unset, PBS uses the server's
+    default queue.
+
+``walltime``
+    Job walltime in PBS format (``HH:MM:SS``), submitted as ``-l walltime=``.
+
+``nodes`` / ``tasks``
+    Chunk count and CPUs per chunk. Together these produce
+    ``-l select=<nodes>:ncpus=<tasks>``. Note ``tasks`` maps to **ncpus**,
+    which is cores per chunk, not MPI ranks -- see ``mpiprocs`` below.
+
+``mpiprocs``
+    MPI ranks per chunk, added to the select statement as ``:mpiprocs=N``.
+    **Optional and unset by default**, since some sites require it and others
+    do not accept it. When unset it is omitted from the select statement
+    entirely. This is the value that determines the number of lines in
+    ``$PBS_NODEFILE`` and therefore the rank count seen by ``mpirun``.
+
+``exclusive``
+    Set to ``'true'`` to request exclusive node placement
+    (``-l place=exclhost:scatter``).
+
+``target``
+    Restrict the job to a specific host, added to the select statement as
+    ``:host=<name>``.
+
+``model``
+    Restrict the job to a node model, added as ``:model=<name>``.
+
+``all_queue_nodes``
+    Use every node in the configured queue rather than a fixed count. Requires
+    ``queue`` to be set, and is mutually exclusive with ``target``.
+
+``qsub_extra``
+    A list of additional ``#PBS`` header lines to add to the kickoff script,
+    for anything not covered above. Note these are emitted as script header
+    lines; options that belong in the select statement cannot be added this
+    way, because the command line ``-l select=`` takes precedence.
+
+``avail_states`` / ``up_states`` / ``reserved_states``
+    Node states that PBS reports which Pavilion should treat as available,
+    usable, or reserved.
+
+Variables
+^^^^^^^^^
+
+In addition to the universal scheduler variables, the PBS scheduler provides
+``sched.queue``, ``sched.walltime`` and ``sched.mpiprocs``. All are deferred,
+so they resolve in the ``run`` section but not in ``build``:
+
+.. code-block:: yaml
+
+    run:
+      cmds:
+        - 'mpirun -np {{sched.mpiprocs}} ./my_app'
+
+``sched.srun_args`` is inherited from the base scheduler variable class but is
+a Slurm concept; under PBS it is always empty. Use ``qsub_extra`` instead.
 
 Scheduler Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tests/scheduling.rst
+++ b/docs/tests/scheduling.rst
@@ -11,7 +11,7 @@ covers the basics of how scheduler plugins operate.
 Included Scheduler Plugins
 --------------------------
 
-Pavilion comes with three scheduler plugins:
+Pavilion comes with four scheduler plugins:
 
 .. code-block:: bash
 
@@ -24,6 +24,7 @@ Pavilion comes with three scheduler plugins:
      raw       | Schedules tests as local processes.
      slurm     | Schedules tests via the Slurm scheduler.
      flux      | Schedules tests via the Flux Framework scheduler.
+     pbs       | Schedules tests via the PBS scheduler.
 
 Scheduler Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/pavilion/schedulers/__init__.py
+++ b/lib/pavilion/schedulers/__init__.py
@@ -4,6 +4,7 @@ from typing import Union
 from .plugins.raw import Raw
 from .plugins.slurm import Slurm
 from .plugins.flux import Flux
+from .plugins.pbs import PBS
 from .advanced import SchedulerPluginAdvanced
 from .basic import SchedulerPluginBasic
 from .config import validate_config
@@ -17,6 +18,7 @@ _builtin_scheduler_plugins = [
     Raw,
     Slurm,
     Flux,
+    PBS
 ]
 
 

--- a/lib/pavilion/schedulers/__init__.py
+++ b/lib/pavilion/schedulers/__init__.py
@@ -4,6 +4,7 @@ from typing import Union
 from .plugins.raw import Raw
 from .plugins.slurm import Slurm
 from .plugins.flux import Flux
+from .plugins.pbs import PBS
 from .advanced import SchedulerPluginAdvanced
 from .basic import SchedulerPluginBasic
 from .config import validate_config
@@ -17,6 +18,7 @@ _builtin_scheduler_plugins = [
     Raw,
     Slurm,
     Flux,
+    PBS,
 ]
 
 

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -72,6 +72,13 @@ def validate_pbs_states(states: List[str]) -> List[str]:
 class PBSVars(SchedulerVariables):
     """Scheduler variables for the Pbs scheduler."""
 
+    EXAMPLE = SchedulerVariables.EXAMPLE.copy()
+    EXAMPLE.update({
+        "test_cmd": "mpirun -np 16 --host node01:8,node02:8",
+        "walltime": "00:01:00",
+        "queue": "normal"
+    })
+
     def _test_cmd(self) -> str:
         """Construct a cmd to run a process under this scheduler, with the
         criteria specified by this test.
@@ -107,12 +114,16 @@ class PBSVars(SchedulerVariables):
 
     @dfr_var_method
     def walltime(self):
+        """Walltime to add to job in PBS format."""
+
         walltime = self._sched_config["pbs"]["walltime"]
 
         return walltime
 
     @dfr_var_method
     def queue(self):
+        """Queue to run job in."""
+
         if self._sched_config["pbs"]["queue"] is not None:
             return self._sched_config["pbs"]["queue"]
         else:

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -408,9 +408,6 @@ class PBS(SchedulerPluginAdvanced):
         _ = self
         cmd = ["qsub"]
 
-        print("Scheduler variables:")
-        print(json.dumps(sched_config["pbs"], indent=5))
-
         if sched_config["pbs"]["walltime"]:
             cmd.append("-l walltime={}".format(sched_config["pbs"]["walltime"]))
 

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -7,11 +7,12 @@ import shutil
 import subprocess
 import time
 import json
-from typing import List, Union, Any, Tuple, Dict
+from typing import List, Union, Any, Tuple, Dict, Optional
 
 import hostlist
 import yaml_config as yc
 from pavilion import sys_vars
+from pavilion.config import PavConfig
 from pavilion.jobs import Job, JobInfo
 from pavilion.status_file import STATES, TestStatusInfo
 from pavilion.types import NodeInfo, NodeList
@@ -56,8 +57,8 @@ class QsubHeader(KickoffScriptHeader):
         return lines
 
 
-def validate_pbs_states(states):
-    """Should be a list of strings (with no punctuation) or None."""
+def validate_pbs_states(states: List[str]) -> List[str]:
+    """Validate a list of PBS states to ensure they have the proper form."""
 
     # We can assume that if this isn't None it's a list.
     for state in states:
@@ -71,10 +72,11 @@ def validate_pbs_states(states):
 class PBSVars(SchedulerVariables):
     """Scheduler variables for the Pbs scheduler."""
 
-    def _test_cmd(self):
+    def _test_cmd(self) -> str:
         """Construct a cmd to run a process under this scheduler, with the
         criteria specified by this test.
         """
+
         pbs_conf = self._sched_config["pbs"]
         nodes = len(self._nodes)
         tasks = self._sched_config["tasks"]
@@ -83,7 +85,6 @@ class PBSVars(SchedulerVariables):
             tasks = int(self.tasks_per_node()) * nodes
 
         if self._sched_config["pbs"]["mpi_cmd"] != "":
-            # cmd: mpirun
             cmd = ["mpirun"]
             cmd.extend(self.mpirun_opts())
             cmd.extend(["--host", ",".join(self._nodes.keys())])
@@ -91,7 +92,7 @@ class PBSVars(SchedulerVariables):
         return " ".join(cmd)
 
     @dfr_var_method
-    def test_cmd(self):
+    def test_cmd(self) -> str:
         """Calls the actual test command and then wraps the return with the wrapper
         provided in the schedule section of the configuration."""
 
@@ -118,40 +119,45 @@ class PBSVars(SchedulerVariables):
             return None
 
 
-def pbs_float(val):
-    """PBS 'float' values might also be 'N/A'."""
+def pbs_float(val: str) -> Optional[float]:
+    """Parse PBS float values. PBS 'float' values might also be 'N/A'."""
+
     if val == "N/A":
         return None
     else:
         return float(val)
 
 
-def pbs_int(val):
-    """PBS 'int' values might also be 'N/A'."""
+def pbs_int(val: str) -> Optional[int]:
+    """Parse PVS int values. PBS 'int' values might also be 'N/A'."""
+
     if val == "N/A":
         return None
     else:
         return int(val)
 
 
-def pbs_str(val):
-    """PBS 'str' values might also be 'N/A'."""
+def pbs_str(val: str) -> Optional[str]:
+    """Parse PBS string values. PBS 'str' values might also be 'N/A'."""
+
     if val == "N/A":
         return None
     else:
         return str(val)
 
 
-def validate_mpi(val):
+def validate_mpi(val: str) -> Optional[str]:
     """PBS 'str' values might also be 'N/A'."""
+
     if val == "N/A":
         return None
     else:
         return str(val)
 
 
-def pbs_states(state):
+def pbs_states(state: str) -> List[str]:
     """Parse a PBS state down to something reasonable."""
+
     states = state.split("+")
 
     if not states:
@@ -192,7 +198,8 @@ class PBS(SchedulerPluginAdvanced):
         "node",
     )
 
-    def _get_config_elems(self):
+    def _get_config_elems(self) -> List[yc.ConfigElement]:
+        """Get the list of config elements for the PBS scheduler plugin."""
 
         elems = [
             yc.ListElem(
@@ -270,7 +277,9 @@ class PBS(SchedulerPluginAdvanced):
         return elems, validators, defaults
 
     @classmethod
-    def parse_node_list(cls, node_list) -> NodeList:
+    def parse_node_list(cls, node_list: List[str]) -> NodeList:
+        """Parse a list of nodes, returning a NodeList object."""
+
         nodes = []
         if node_list is None or node_list == "":
             return NodeList([])
@@ -281,7 +290,7 @@ class PBS(SchedulerPluginAdvanced):
 
         return NodeList(nodes)
 
-    def _get_alloc_nodes(self, job) -> NodeList:
+    def _get_alloc_nodes(self, job: Job) -> NodeList:
         """Get the list of allocated nodes."""
 
         _ = job
@@ -299,9 +308,11 @@ class PBS(SchedulerPluginAdvanced):
             )
 
     @staticmethod
-    def _get_raw_node_data(sched_config) -> Tuple[Union[List[Any], None], Any]:
+    def _get_raw_node_data(sched_config: Dict[str, Any]
+                            ) -> Tuple[List[Dict[str, Dict]], Dict[str, Dict]]:
         """Use the `pbsnodes` command to collect data on nodes.
         Types are converted according to self.FIELD_TYPES."""
+
         try:
             output = subprocess.check_output(
                 ["pbsnodes", "-avFjson"], stderr=subprocess.PIPE
@@ -319,7 +330,10 @@ class PBS(SchedulerPluginAdvanced):
 
         return raw_node_data, {"reservations": {}}
 
-    def _transform_raw_node_data(self, sched_config, node_data, extra) -> NodeInfo:
+    def _transform_raw_node_data(self,
+                                 sched_config: Dict[str, Any],
+                                 node_data: Dict[str, str],
+                                 extra: Dict[str, Any]) -> NodeInfo:
         """Translate the gathered data into a NodeInfo dict."""
 
         parsed_data = self._pbsnodes_parse(node_data)
@@ -364,9 +378,10 @@ class PBS(SchedulerPluginAdvanced):
 
         return node_info
 
-    def _filter_custom(
-        self, sched_config: dict, node_name: str, node: NodeInfo
-    ) -> Union[str, None]:
+    def _filter_custom(self,
+                       sched_config: Dict[str, Any],
+                       node_name: str,
+                       node: NodeInfo) -> Optional[str]:
         """Filter nodes by features. (Returns why a node should be filtered out, or None if it
         shouldn't be."""
 
@@ -396,13 +411,12 @@ class PBS(SchedulerPluginAdvanced):
 
     def _kickoff(
         self,
-        pav_cfg,
+        pav_cfg: PavConfig,
         job: Job,
-        sched_config: dict,
+        sched_config: Dict[str, Any],
         job_name: str,
-        nodes: Union[NodeList, None] = None,
-        node_range: Union[Tuple[int, int], None] = None,
-    ) -> JobInfo:
+        nodes: Optional[NodeList] = None,
+        node_range: Optional[Tuple[int, int]] = None) -> JobInfo:
         """Submit the kick off script using qsub."""
 
         _ = self
@@ -441,9 +455,9 @@ class PBS(SchedulerPluginAdvanced):
         )
 
     @staticmethod
-    def _pbsnodes_parse(section: str) -> Dict[str, str]:
-        # pbsnodes json output imports cleanly into dicts
-        # without modification
+    def _pbsnodes_parse(section: Dict[str, str]) -> Dict[str, str]:
+        """Transform pbsnodes output into a dictionary. pbsnodes json output imports
+        cleanly into dicts without modification."""
 
         node_info = {}
 
@@ -453,7 +467,7 @@ class PBS(SchedulerPluginAdvanced):
         return node_info
 
     @staticmethod
-    def _qstat(*args, timeout=30) -> List[Dict]:
+    def _qstat(*args, timeout: int = 30) -> List[Dict[str, Any]]:
         """Run qstat show and return the parsed output.
 
         :param list(str) args: Additional args to pbsnodes.
@@ -514,7 +528,7 @@ class PBS(SchedulerPluginAdvanced):
         "T",
     ]
 
-    def _job_status(self, pav_cfg, job_info: JobInfo) -> TestStatusInfo:
+    def _job_status(self, pav_cfg: PavConfig, job_info: JobInfo) -> TestStatusInfo:
         """Get the current status of the PBS job for the given test."""
 
         sys_name = sys_vars.get_vars(True)["sys_name"]
@@ -599,7 +613,7 @@ class PBS(SchedulerPluginAdvanced):
             when=time.time(),
         )
 
-    def cancel(self, job_info: JobInfo) -> Union[str, None]:
+    def cancel(self, job_info: JobInfo) -> Optional[str]:
         """qdel the job attached to the given test."""
 
         _ = self

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -7,12 +7,11 @@ import shutil
 import subprocess
 import time
 import json
-from typing import List, Union, Any, Tuple, Dict, Optional
+from typing import List, Union, Any, Tuple, Dict
 
 import hostlist
 import yaml_config as yc
 from pavilion import sys_vars
-from pavilion.config import PavConfig
 from pavilion.jobs import Job, JobInfo
 from pavilion.status_file import STATES, TestStatusInfo
 from pavilion.types import NodeInfo, NodeList
@@ -21,634 +20,522 @@ from ..advanced import SchedulerPluginAdvanced
 from ..config import validate_list
 from ..scheduler import KickoffScriptHeader
 from ..vars import SchedulerVariables
-from ...errors import SchedulerPluginError
+from ...errors import SchedulerPluginError, SchedConfigError
 
 
 class QsubHeader(KickoffScriptHeader):
-    """Provides header information specific to qsub files for the
-    pbs kickoff script."""
+    """Provides header information specific to qsub files for the PBS kickoff script."""
 
     def _kickoff_lines(self) -> List[str]:
         """Get the qsub header lines."""
 
         lines = []
 
-        # White space is discouraged in job names.
-        job_name = "__".join(self._job_name.split())
+        # PBS job names: first char must be alphabetic, only alphanumeric/_/- allowed.
+        job_name = re.sub(r'[^a-zA-Z0-9_\-]', '_', self._job_name)
+        if not job_name or not job_name[0].isalpha():
+            job_name = 'pav_' + job_name
+        lines.append('#PBS -N {}'.format(job_name))
 
-        lines.append('#PBS -N "{}"'.format(job_name))
-
-        queue = self._config["pbs"]["queue"]
+        queue = self._config['pbs']['queue']
         if queue is not None:
-            lines.append("#PBS -q {}".format(queue))
+            lines.append('#PBS -q {}'.format(queue))
+        else:
+            lines.append('#PBS -q normal'.format(queue))
 
-        # Mandantory Account name
-        if self._sched_vars.account() != "":
-            lines.append("#PBS -A {}".format(self._sched_vars.account()))
+        # Mandatory account name
+        if self._sched_vars.account():
+            lines.append('#PBS -A {}'.format(self._sched_vars.account()))
 
-        if self._sched_vars.walltime() != "":
-            lines.append("#PBS -l walltime={}".format(self._sched_vars.walltime()))
+        # Exclusive node allocation
+        if self._config['pbs'].get('exclusive'):
+            lines.append('#PBS -l place=excl')
 
-        # Extra Qsub arguments
-        for line in self._config["pbs"]["qsub_extra"]:
-            lines.append("#PBS {}".format(line))
+        # Extra qsub arguments
+        for line in self._config['pbs']['qsub_extra']:
+            lines.append('#PBS {}'.format(line))
 
         return lines
 
 
-def validate_pbs_states(states: List[str]) -> List[str]:
-    """Validate a list of PBS states to ensure they have the proper form."""
-
-    # We can assume that if this isn't None it's a list.
+def validate_pbs_states(states):
+    """Should be a list of strings (with no punctuation) or None."""
     for state in states:
-        if not re.match("^[a-z-]*$", state):
-            raise ValueError(
-                "Invalid PBS state '{}'. PBS states should be alpha numeric"
-            )
+        if not re.match(r'^[a-z-]*$', state):
+            raise SchedConfigError(
+                "Invalid PBS state '{}'. PBS states should be alpha numeric.".format(state))
     return states
 
 
 class PBSVars(SchedulerVariables):
-    """Scheduler variables for the Pbs scheduler."""
+    """Scheduler variables for the PBS scheduler."""
 
-    EXAMPLE = SchedulerVariables.EXAMPLE.copy()
-    EXAMPLE.update({
-        "test_cmd": "mpirun -np 16 --host node01:8,node02:8",
-        "walltime": "00:01:00",
-        "queue": "normal"
-    })
-
-    def _test_cmd(self) -> str:
-        """Construct a cmd to run a process under this scheduler, with the
-        criteria specified by this test.
-        """
-
-        pbs_conf = self._sched_config["pbs"]
+    def _test_cmd(self):
+        """Construct a cmd to run a process under this scheduler."""
+        pbs_conf = self._sched_config['pbs']
         nodes = len(self._nodes)
-        tasks = self._sched_config["tasks"]
+        tasks = self._sched_config['tasks']
 
         if tasks is None:
             tasks = int(self.tasks_per_node()) * nodes
 
         cmd = []
-
-        if self._sched_config["pbs"]["mpi_cmd"] != "":
-            cmd = ["mpirun"]
+        if pbs_conf['mpi_cmd']:
+            cmd = ['mpirun']
             cmd.extend(self.mpirun_opts())
-            cmd.extend(["--host", ",".join(self._nodes.keys())])
+            cmd.extend(['--host', ','.join(self._nodes.keys())])
 
-        return " ".join(cmd)
-
-    @dfr_var_method
-    def test_cmd(self) -> str:
-        """Calls the actual test command and then wraps the return with the wrapper
-        provided in the schedule section of the configuration."""
-
-        # Removes all the None values to avoid getting a TypeError while trying to
-        # join two commands
-        return " ".join(
-            filter(
-                lambda item: item is not None,
-                [self._test_cmd(), self._sched_config["wrapper"]],
-            )
-        )
+        return ' '.join(cmd)
 
     @dfr_var_method
-    def walltime(self) -> str:
-        """Walltime to add to job in PBS format."""
-
-        walltime = self._sched_config["pbs"]["walltime"]
-
-        return walltime
+    def test_cmd(self):
+        """Calls the actual test command and wraps the return with the configured wrapper."""
+        # Filter None values to avoid TypeError when joining
+        parts = filter(None, [self._test_cmd(), self._sched_config.get('wrapper')])
+        return ' '.join(parts)
 
     @dfr_var_method
-    def queue(self) -> Optional[str]:
-        """Queue to run job in."""
+    def walltime(self):
+        """Return the configured walltime."""
+        return self._sched_config['pbs']['walltime']
 
-        if self._sched_config["pbs"]["queue"] is not None:
-            return self._sched_config["pbs"]["queue"]
-        else:
-            return None
+    @dfr_var_method
+    def queue(self):
+        """Return the configured queue, or empty string if not set."""
+        return self._sched_config['pbs']['queue'] or ''
 
-
-def pbs_float(val: str) -> Optional[float]:
-    """Parse PBS float values. PBS 'float' values might also be 'N/A'."""
-
-    if val == "N/A":
-        return None
-    else:
-        return float(val)
+def pbs_float(val):
+    """PBS 'float' values might also be 'N/A'."""
+    return None if val == 'N/A' else float(val)
 
 
-def pbs_int(val: str) -> Optional[int]:
-    """Parse PVS int values. PBS 'int' values might also be 'N/A'."""
-
-    if val == "N/A":
-        return None
-    else:
-        return int(val)
+def pbs_int(val):
+    """PBS 'int' values might also be 'N/A'."""
+    return None if val == 'N/A' else int(val)
 
 
-def pbs_str(val: str) -> Optional[str]:
-    """Parse PBS string values. PBS 'str' values might also be 'N/A'."""
-
-    if val == "N/A":
-        return None
-    else:
-        return str(val)
-
-
-def validate_mpi(val: str) -> Optional[str]:
+def pbs_str(val):
     """PBS 'str' values might also be 'N/A'."""
-
-    if val == "N/A":
-        return None
-    else:
-        return str(val)
+    return None if val == 'N/A' else str(val)
 
 
-def pbs_states(state: str) -> List[str]:
+
+
+
+def pbs_states(state):
     """Parse a PBS state down to something reasonable."""
-
-    states = state.split("+")
+    states = state.split('+')
 
     if not states:
-        return ["UNKNOWN"]
+        return ['UNKNOWN']
 
-    for i in range(len(states)):
-        state = states[i]
-        if state.endswith("$") or state.endswith("*"):
-            states[i] = state[:-1]
+    # STYLE FIX: use enumerate instead of range(len(...))
+    for i, s in enumerate(states):
+        if s.endswith('$') or s.endswith('*'):
+            states[i] = s[:-1]
 
     return states
 
 
+
 class PBS(SchedulerPluginAdvanced):
-    """Schedule tests with Pbs!"""
+    """Schedule tests with PBS!"""
 
     VAR_CLASS = PBSVars
     KICKOFF_SCRIPT_HEADER_CLASS = QsubHeader
 
+    # Pbs status mappings
+    SCHED_WAITING = ['Q', 'W']
+    SCHED_RUN = ['R', 'B']
+    SCHED_CANCELLED = ['E', 'X']
+    SCHED_ERROR = ['F']
+    SCHED_OTHER = ['H', 'U', 'S', 'T']
+
     def __init__(self):
-        super().__init__("pbs", "Schedules tests via the PBS scheduler.")
+        super().__init__('pbs', "Schedules tests via the PBS scheduler.")
 
-    JOB_SHARE_KEY_ATTRS = SchedulerPluginAdvanced.JOB_SHARE_KEY_ATTRS + [
-        "pbs.qsub_extra"
-    ]
+    JOB_SHARE_KEY_ATTRS = SchedulerPluginAdvanced.JOB_SHARE_KEY_ATTRS + ['pbs.qsub_extra', 'pbs.exclusive']
 
-    MPI_CMD_MPIRUN = "mpirun"
+    MPI_CMD_MPIRUN = 'mpirun'
     MPIRUN_BIND_OPTS = (
-        "slot",
-        "hwthread",
-        "core",
-        "L1cache",
-        "L2cache",
-        "L3cache",
-        "socket",
-        "numa",
-        "board",
-        "node",
+        'slot', 'hwthread', 'core', 'L1cache', 'L2cache', 'L3cache',
+        'socket', 'numa', 'board', 'node'
     )
 
-    def _get_config_elems(self) -> List[yc.ConfigElement]:
-        """Get the list of config elements for the PBS scheduler plugin."""
-
+    def _get_config_elems(self):
         elems = [
-            yc.ListElem(
-                name="avail_states",
-                sub_elem=yc.StrElem(),
-                help_text="When looking for immediately available "
-                "nodes, they must be in one of these "
-                "states.",
-            ),
-            yc.ListElem(
-                name="up_states",
-                sub_elem=yc.StrElem(),
-                help_text="When looking for nodes that could be  "
-                "allocated, they must be in one of these "
-                "states.",
-            ),
-            yc.ListElem(
-                name="reserved_states",
-                sub_elem=yc.StrElem(),
-                help_text="Ignore nodes in these states, unless a reservation "
-                "was specified.",
-            ),
-            yc.ListElem(
-                name="qsub_extra",
-                sub_elem=yc.StrElem(),
-                help_text="Extra arguments to add as qsub header lines. "
-                "Example: ['--deadline now+20hours']",
-            ),
-            yc.StrElem(
-                name="walltime",
-                help_text="Walltime to add to job in PBS format." "Example: 00:01:00",
-            ),
-            yc.StrElem(
-                name="queue", help_text="Queue to run job in." "Example: normal"
-            ),
-            yc.StrElem(name="tasks"),
-            yc.StrElem(name="nodes"),
-            yc.StrElem(
-                name="mpi_cmd",
-                help_text="What command to use to start mpi jobs. If empty "
-                "mpi will not be used Options are {}.".format(self.MPI_CMD_MPIRUN),
-            ),
+            yc.ListElem(name='avail_states',
+                        sub_elem=yc.StrElem(),
+                        help_text="When looking for immediately available nodes, "
+                                  "they must be in one of these states."),
+            yc.ListElem(name='up_states',
+                        sub_elem=yc.StrElem(),
+                        help_text="When looking for nodes that could be allocated, "
+                                  "they must be in one of these states."),
+            yc.StrElem(name='all_queue_nodes',
+                       help_text="If set, use all nodes in the queue instead of a fixed count."),
+            yc.ListElem(name='reserved_states',
+                        sub_elem=yc.StrElem(),
+                        help_text="Ignore nodes in these states, unless a reservation "
+                                  "was specified."),
+            yc.ListElem(name='qsub_extra',
+                        sub_elem=yc.StrElem(),
+                        help_text="Extra arguments to add as qsub header lines. "
+                                  "Example: ['--deadline now+20hours']"),
+            yc.StrElem(name='walltime',
+                       help_text="Walltime to add to job in PBS format. "
+                                 "Example: 00:01:00"),
+            yc.StrElem(name='target',
+                       help_text="Target a specific host. "
+                                 "Example: node001 "),
+            yc.StrElem(name='queue',
+                       help_text="Queue to run job in. Example: normal"),
+            yc.StrElem(name='tasks'),
+            yc.StrElem(name='nodes'),
+            yc.StrElem(name='mpi_cmd',
+                       help_text="Command to use to start MPI jobs. If empty, "
+                                 "MPI will not be used. Options: {}.".format(self.MPI_CMD_MPIRUN)),
+            yc.StrElem(name='model',
+                       help_text="Node model to target. Example: broadwell"),
+            yc.StrElem(name='exclusive',
+                       help_text="Request exclusive node allocation (-l place=excl). "
+                                 "Set to 'true' to enable."),
         ]
 
         defaults = {
-            "up_states": [
-                "job-exclusive",
-                "job-busy",
-                "free",
-                "busy",
-                "resv-exclusive",
-            ],
-            "avail_states": ["free"],
-            "reserved_states": ["resv-exclusive"],
-            "tasks": 1,
-            "nodes": 1,
-            "walltime": "00:01:00",
-            "queue": None,
-            "qsub_extra": [],
-            "mpi_cmd": "",
+            'up_states': ['job-exclusive', 'job-busy', 'free', 'busy', 'resv-exclusive'],
+            'avail_states': ['free'],
+            'reserved_states': ['resv-exclusive'],
+            'tasks': 1,
+            'nodes': 1,
+            'walltime': '00:01:00',
+            'queue': None,
+            'qsub_extra': [],
+            'mpi_cmd': [],
+            'target': None,
+            'all_queue_nodes': None,
+            'model': None,
+            'exclusive': None,
         }
 
         validators = {
-            "up_states": validate_pbs_states,
-            "avail_states": validate_pbs_states,
-            "reserved_states": validate_pbs_states,
-            "tasks": pbs_int,
-            "nodes": pbs_int,
-            "qsub_extra": validate_list,
-            "walltime": pbs_str,
-            "queue": pbs_str,
-            "mpi_cmd": validate_mpi,
+            'up_states': validate_pbs_states,
+            'avail_states': validate_pbs_states,
+            'reserved_states': validate_pbs_states,
+            'tasks': pbs_int,
+            'nodes': pbs_int,
+            'qsub_extra': validate_list,
+            'walltime': pbs_str,
+            'queue': pbs_str,
+            'mpi_cmd': pbs_str,
+            'target': pbs_str,
+            'all_queue_nodes': pbs_int,
+            'model': pbs_str,
+            'exclusive': lambda v: v if v is None else str(v).lower() in ('true', '1', 'yes'),
         }
 
         return elems, validators, defaults
 
     @classmethod
-    def parse_node_list(cls, node_list: Union[str, List[str], None]) -> NodeList:
-        """Parse a list of nodes, returning a NodeList object."""
-
-        nodes = []
-        if node_list is None or node_list == "":
+    def parse_node_list(cls, node_list) -> NodeList:
+        if not node_list:
             return NodeList([])
 
-        for node in node_list:
-            if node.isalpha():
-                nodes.append(node)
-
+        # BUG FIX: isalpha() rejects hostnames with digits/hyphens; use a truthy check instead
+        # Deduplicate while preserving order: PBS_NODEFILE lists one entry per CPU slot,
+        # so a node with 2 CPUs appears twice. dict.fromkeys preserves insertion order.
+        nodes = list(dict.fromkeys(n for n in node_list if n))
         return NodeList(nodes)
 
-    def _get_alloc_nodes(self, job: Job) -> NodeList:
-        """Get the list of allocated nodes."""
 
-        _ = job
+    def _get_alloc_nodes(self, job) -> NodeList:
+        """Get the list of allocated nodes."""
+        try:
+            nodefile = os.environ['PBS_NODEFILE']
+        except KeyError:
+            raise SchedulerPluginError("PBS_NODEFILE environment variable is not set.")
+
         node_list = []
 
-        nodefile = os.environ["PBS_NODEFILE"]
-
         try:
-            with open(nodefile, "r") as fin:
-                node_list = fin.read().split("\n")
+            with open(nodefile, 'r') as nf:
+                n_tmp = nf.read().split('\n')
         except OSError as err:
-            raise SchedulerPluginError(f"Could not open PBS nodefile: {nodefile}.", err)
-
-        try:
-            return self.parse_node_list(node_list)
-        except ValueError as err:
             raise SchedulerPluginError(
-                "Invalid pbs nodelist: '{}'".format(node_list), err
-            )
+                "Could not read PBS nodefile '{}'.".format(nodefile), prior_error=err)
 
-    # pylint: disable=no-self-use
-    def _get_raw_node_data(self,
-                           sched_config: Dict[str, Any]
-                          ) -> Tuple[List[Dict[str, Dict]], Dict[str, Dict]]:
-        """Use the `pbsnodes` command to collect data on nodes.
-        Types are converted according to self.FIELD_TYPES."""
+        for n in n_tmp:
+            if '.' in n:
+                node_list.append(n.split('.')[0])
+            else:
+                node_list.append(n)
 
+        return self.parse_node_list(node_list)
+
+    def _get_raw_node_data(self, sched_config) -> Tuple[Union[List[Any], None], Any]:
+        """Use `pbsnodes` to collect data on nodes."""
         try:
-            output = subprocess.check_output(
-                ["pbsnodes", "-avFjson"], stderr=subprocess.PIPE
-            )
-            nodes_json = json.loads(output).get("nodes", {})
+            output = subprocess.check_output(['pbsnodes', '-avFjson'], stderr=subprocess.PIPE)
+            nodes_json = json.loads(output).get('nodes', {})
         except (subprocess.CalledProcessError, json.JSONDecodeError) as err:
             raise SchedulerPluginError("Failed to get pbsnodes data", err)
 
         raw_node_data = []
         for node_name, data in nodes_json.items():
-            res = data.get("resources_available", {})
-            res["queue"] = data.get("queue", None)
-            res["state"] = data.get("state", "unknown")
+            res = data.get('resources_available', {})
+            queue = data.get('queue')
+            res['queue'] = [queue] if queue else []
+            res['state'] = data.get('state', 'unknown')
             raw_node_data.append({node_name: res})
 
-        return raw_node_data, {"reservations": {}}
+        return raw_node_data, {'reservations': {}}
 
-    def _transform_raw_node_data(self,
-                                 sched_config: Dict[str, Any],
-                                 node_data: Dict[str, str],
-                                 extra: Dict[str, Any]) -> NodeInfo:
-        """Translate the gathered data into a NodeInfo dict."""
-
+    def _transform_raw_node_data(self, sched_config, node_data, extra) -> NodeInfo:
+        """Translate gathered data into a NodeInfo dict."""
         parsed_data = self._pbsnodes_parse(node_data)
         node_info = NodeInfo({})
 
+        key_map = (
+            ('vnode', 'name'),
+            ('arch', 'arch'),
+            ('ncpus', 'cpus'),
+            ('mem', 'mem'),
+            ('state', 'states'),
+            ('queue', 'partitions'),
+        )
+
         for node in parsed_data:
-            for orig_key, dest_key in (
-                ("vnode", "name"),
-                ("arch", "arch"),
-                ("ncpus", "cpus"),
-                ("mem", "mem"),
-                ("state", "states"),
-                ("queue", "partitions"),
-            ):
+            for orig_key, dest_key in key_map:
                 node_info[dest_key] = parsed_data[node].get(orig_key)
 
-        # Split and clean up the states
-        if node_info["states"] is not None:
-            node_info["states"] = [
-                state.strip().rstrip(",") for state in node_info["states"].split(",")
+        # Split and clean up states
+        if node_info['states'] is not None:
+            node_info['states'] = [
+                state.strip().rstrip(',') for state in node_info['states'].split(',')
             ]
-        else:
-            node_info["states"] = None
 
-        # Convert to an integer in GBytes
-        node_info["mem"] = int(node_info["mem"][:-2]) * 1024**2
+        # Convert mem to bytes; PBS reports values like '4194304kb'
+        if node_info.get('mem'):
+            mem_str = node_info['mem']
+            suffix = mem_str[-2:].lower()
+            value = int(mem_str[:-2])
+            multipliers = {'kb': 1024, 'mb': 1024 ** 2, 'gb': 1024 ** 3}
+            node_info['mem'] = value * multipliers.get(suffix, 1)
 
-        # Convert to an integer
-        node_info["cpus"] = int(node_info["cpus"])
+        # Convert cpus to integer
+        if node_info.get('cpus'):
+            node_info['cpus'] = int(node_info['cpus'])
 
-        up_states = sched_config["pbs"]["up_states"]
-        avail_states = sched_config["pbs"]["avail_states"]
-        reserved_states = sched_config["pbs"]["reserved_states"]
-        if sched_config["reservation"]:
-            up_states = up_states + reserved_states
-            avail_states = avail_states + reserved_states
+        pbs_config = sched_config['pbs']
+        up_states = list(pbs_config['up_states'])
+        avail_states = list(pbs_config['avail_states'])
+        reserved_states = pbs_config['reserved_states']
 
-        node_info["up"] = all(state in up_states for state in node_info["states"])
-        node_info["available"] = all(
-            state in avail_states for state in node_info["states"]
-        )
+        if sched_config.get('reservation'):
+            up_states += reserved_states
+            avail_states += reserved_states
+
+        states = node_info.get('states') or []
+        node_info['up'] = all(state in up_states for state in states)
+        node_info['available'] = all(state in avail_states for state in states)
 
         return node_info
 
-    def _filter_custom(self,
-                       sched_config: Dict[str, Any],
-                       node_name: str,
-                       node: NodeInfo) -> Optional[str]:
-        """Filter nodes by features. (Returns why a node should be filtered out, or None if it
-        shouldn't be."""
-
-        _ = self
-
-        # For now, don't do any special filtering. We may want to revisit this later.
+    def _filter_custom(self, sched_config: dict, node_name: str, node: NodeInfo) \
+            -> Union[str, None]:
+        """Filter nodes by features. Returns reason to filter, or None to keep."""
+        if ('down' in (node.get('states') or [])) or ('offline' in (node.get('states') or [])):
+            print(node)
+            return "node unavailable"
+        queue = sched_config['pbs'].get('queue')
+        if queue:
+            if queue not in (node.get('partitions')): # or []):
+                return "node not in queue"
         return None
 
     def _available(self) -> bool:
-        """Looks for several pbs commands, and tests pbs can talk to the
-        pbs db."""
-
-        _ = self
-
-        for command in "pbsnodes", "qsub", "qstat":
+        """Check that PBS commands exist and PBS can talk to the scheduler DB."""
+        for command in ('pbsnodes', 'qsub', 'qstat'):
             if shutil.which(command) is None:
                 return False
 
-        # Try to get basic system info from sinfo. Should return not-zero
-        # on failure.
         ret = subprocess.call(
-            ["qstat"],
+            ['qstat'],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-
         return ret == 0
 
-    def _kickoff(
-        self,
-        pav_cfg: PavConfig,
-        job: Job,
-        sched_config: Dict[str, Any],
-        job_name: str,
-        nodes: Optional[NodeList] = None,
-        node_range: Optional[Tuple[int, int]] = None) -> JobInfo:
-        """Submit the kick off script using qsub."""
+    def _get_queue_nodect(self, queue):
+        nodes = self._nodes
+        nodect = 0
+        for node in nodes:
+            if nodes[node]['partitions']:
+                if queue in nodes[node]['partitions']:
+                    if ('down' not in nodes[node]['states']) and ('offline' not in nodes[node]['states']):
+                        nodect += 1
+        return nodect
 
-        _ = self
-        cmd = ["qsub"]
+    def _kickoff(self, pav_cfg, job: Job, sched_config: dict, job_name: str,
+                 nodes: Union[NodeList, None] = None,
+                 node_range: Union[Tuple[int, int], None] = None) -> JobInfo:
+        """Submit the kickoff script using qsub."""
 
-        if sched_config["pbs"]["walltime"]:
-            cmd.append("-l walltime={}".format(sched_config["pbs"]["walltime"]))
+        pbs_cfg = sched_config['pbs']
+        cmd = ['qsub']
 
-        if sched_config["pbs"]["nodes"] or sched_config["pbs"]["tasks"]:
-            nodes = sched_config["pbs"].get("nodes", 1)
-            tasks = sched_config["pbs"].get("tasks", 1)
-            cmd.append("-l select={}:ncpus={}".format(nodes, tasks))
+        if pbs_cfg.get('all_queue_nodes') and pbs_cfg.get('target'):
+            raise SchedulerPluginError(
+                "PBS config error: 'all_queue_nodes' and 'target' are mutually exclusive. "
+                "Remove one before submitting.")
 
-        proc = subprocess.Popen(
-            cmd
-            + ["-o={}".format(job.sched_log.as_posix()), job.kickoff_path.as_posix()],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        if pbs_cfg.get('walltime'):
+            cmd.append('-l walltime={}'.format(pbs_cfg['walltime']))
+
+        if pbs_cfg.get('nodes') or pbs_cfg.get('tasks'):
+            n = pbs_cfg.get('nodes', 1)
+            if pbs_cfg.get('all_queue_nodes'):
+               n = self._get_queue_nodect(pbs_cfg.get('queue'))
+            t = pbs_cfg.get('tasks', 1)
+            if pbs_cfg.get('target') and not pbs_cfg.get('all_queue_nodes'):
+                select = '-l select={}:ncpus={}:host={}'.format(n, t, pbs_cfg['target'])
+            else:
+                select = '-l select={}:ncpus={}'.format(n, t)
+            if pbs_cfg.get('model'):
+                select += ':model={}'.format(pbs_cfg['model'])
+            cmd.append(select)
+
+        cmd += ['-o={}'.format(job.sched_log.as_posix()), job.kickoff_path.as_posix()]
+
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = proc.communicate()
 
         if proc.poll() != 0:
             raise SchedulerPluginError(
-                "Qsub failed for kickoff script '{}': {}".format(
-                    job.kickoff_path, stderr.decode("utf8")
-                )
+                "Qsub failed for kickoff script '{}': {}"
+                .format(job.kickoff_path, stderr.decode('utf8'))
             )
 
-        sys_name = sys_vars.get_vars(True)["sys_name"]
+        sys_name = sys_vars.get_vars(True)['sys_name']
+        return JobInfo({
+            'id': stdout.decode('utf-8').strip().split('.')[0],
+            'sys_name': sys_name,
+        })
 
-        return JobInfo(
-            {
-                "id": stdout.decode("UTF-8").strip().split(".")[0],
-                "sys_name": sys_name,
-            }
-        )
+    def _pbsnodes_parse(self, section: dict) -> Dict[str, str]:
+        """Parse pbsnodes JSON output into a dict."""
+        # SIMPLIFICATION: dict.update({k: v}) in a loop is just dict.copy()
+        return dict(section)
 
-    @staticmethod
-    def _pbsnodes_parse(section: Dict[str, str]) -> Dict[str, str]:
-        """Transform pbsnodes output into a dictionary. pbsnodes json output imports
-        cleanly into dicts without modification."""
+    def _qstat(self, *args, timeout=30) -> List[Dict]:
+        """Run qstat and return the parsed output.
 
-        node_info = {}
-
-        for node in section:
-            node_info.update({node: section[node]})
-
-        return node_info
-
-    @staticmethod
-    def _qstat(*args, timeout: int = 30) -> List[Dict[str, Any]]:
-        """Run qstat show and return the parsed output.
-
-        :param list(str) args: Additional args to pbsnodes.
-        :param int timeout: How long to wait for results.
+        :param args: Additional args to qstat.
+        :param timeout: How long to wait for results (seconds).
         """
-
-        cmd = ["qstat", "-fFjson"] + list(args)
+        cmd = ['qstat', '-fFjson'] + list(args)
 
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         try:
             stdout, stderr = proc.communicate(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            raise TimeoutError("Timed out waiting for pbsnodes.")
+        except subprocess.TimeoutExpired as err:
+            raise SchedulerPluginError("Timed out waiting for qstat.", prior_error=err)
 
-        stdout = stdout.decode("utf8")
-        stderr = stderr.decode("utf8")
+        stdout = stdout.decode('utf-8')
+        stderr = stderr.decode('utf-8')
 
         if proc.poll() != 0:
-            raise ValueError(stderr)
+            raise SchedulerPluginError("qstat failed: {}".format(stderr))
 
-        job_dict = json.loads(stdout)["Jobs"]
+        try:
+            job_dict = json.loads(stdout)['Jobs']
+        except json.JSONDecodeError as err:
+            raise SchedulerPluginError(
+                "Could not parse qstat output as JSON.", prior_error=err)
+        except KeyError:
+            raise SchedulerPluginError(
+                "qstat JSON output missing 'Jobs' key.")
 
-        results = []
-        results.append(job_dict)
+        return [job_dict]
 
-        return results
-
-    # Pbs status mappings
-    # SCHED_WAITING - The job is still queued and waiting to start.
-    SCHED_WAITING = (
-        "Q",
-        "W",
-    )
-    # SCHED_RUN - From pavilion's perspective, these all mean Pavilion should
-    # look to the test's status file for more information.
-    SCHED_RUN = (
-        "R",
-        "B",
-    )
-    # SCHED_CANCELLED - The job was cancelled. We can't expect to see more
-    # from the test status, as the test probably never started.
-    SCHED_CANCELLED = (
-        "E",
-        "X",
-    )
-    # SCHED_ERROR - Something went wrong, but the job was running at some
-    # point.
-    SCHED_ERROR = (
-        "F",
-    )
-    # SCHED_OTHER - Pavilion shouldn't see these, and will log them when it
-    # does.
-    SCHED_OTHER = (
-        "H",
-        "U",
-        "S",
-        "T",
-    )
-
-    def _job_status(self, pav_cfg: PavConfig, job_info: JobInfo) -> TestStatusInfo:
-        """Get the current status of the PBS job for the given test."""
-
-        sys_name = sys_vars.get_vars(True)["sys_name"]
-        if job_info["sys_name"] != sys_name:
+    def _job_status(self, pav_cfg, job_info: JobInfo) -> TestStatusInfo:
+        """Get the current status of the PBS job."""
+        sys_name = sys_vars.get_vars(True)['sys_name']
+        if job_info['sys_name'] != sys_name:
             return TestStatusInfo(
                 STATES.SCHEDULED,
-                "Job started on a different cluster ({}).".format(sys_name),
+                "Job started on a different cluster ({}).".format(sys_name)
             )
 
         try:
-            job_data = self._qstat(job_info["id"])
-        except ValueError as err:
-            return TestStatusInfo(
-                state=STATES.SCHED_ERROR, note=str(err), when=time.time()
-            )
-        except TimeoutError:
-            return TestStatusInfo(
-                state=STATES.SCHED_WARNING,
-                note=f"Timed out waiting for pbsnodes (job {job_info['id']})",
-                when=time.time(),
-            )
+            job_data = self._qstat(job_info['id'])
+        except SchedulerPluginError as err:
+            if isinstance(err.prior_error, subprocess.TimeoutExpired):
+                return TestStatusInfo(
+                    state=STATES.SCHED_WARNING,
+                    note="Timed out waiting for qstat (job {})".format(job_info['id']),
+                    when=time.time()
+                )
+            return TestStatusInfo(state=STATES.SCHED_ERROR, note=str(err), when=time.time())
 
-        if len(job_data) == 0:
+        if not job_data:
             return TestStatusInfo(
                 state=STATES.SCHED_ERROR,
-                note="Could not find job {}".format(job_info["id"]),
-                when=time.time(),
+                note="Could not find job {}".format(job_info['id']),
+                when=time.time()
             )
 
-        # qstat returns a list. There should only be one item in that
-        # list though.
-        if len(job_data) > 0:
-            job_data = job_data.pop(0)
-        else:
-            return TestStatusInfo(
-                state=STATES.SCHEDULED,
-                note=(
-                    "Could not find info on pbs job '{}' in pbs.".format(job_info["id"])
-                ),
-                when=time.time(),
-            )
+        # BUG FIX: original code checked len > 0 twice, with dead code in the else branch
+        job_data = job_data.pop(0)
 
-        job = " ".join(list(job_data.keys()))
-        job_state = job_data[job].get("job_state", "UNKNOWN")
+        job_id = list(job_data.keys())[0]
+        job_state = job_data[job_id].get('job_state', 'UNKNOWN')
+
         if job_state in self.SCHED_WAITING:
             return TestStatusInfo(
                 state=STATES.SCHEDULED,
-                note=(
-                    "Job {} has state '{}', reason '{}'".format(
-                        job_info["id"], job_state, job_info.get("Reason")
-                    )
-                ),
-                when=time.time(),
+                note="Job {} has state '{}', reason '{}'".format(
+                    job_info['id'], job_state, job_info.get('Reason')),
+                when=time.time()
             )
         elif job_state in self.SCHED_RUN:
             return TestStatusInfo(
                 state=STATES.SCHED_RUNNING,
-                note=(
-                    "Job is running or about to run. Has job state {}".format(job_state)
-                ),
-                when=time.time(),
+                note="Job is running or about to run. Has job state {}".format(job_state),
+                when=time.time()
             )
         elif job_state in self.SCHED_ERROR:
             return TestStatusInfo(
                 STATES.SCHED_ERROR,
-                "The scheduler killed the job, it has job state '{}'".format(job_state),
+                "The scheduler killed the job, it has job state '{}'".format(job_state)
             )
-
         elif job_state in self.SCHED_CANCELLED:
-            # The job appears to have been cancelled without running.
             return TestStatusInfo(
                 STATES.SCHED_CANCELLED,
-                "Job cancelled, has job state '{}'".format(job_state),
+                "Job cancelled, has job state '{}'".format(job_state)
             )
 
-        # The best we can say is that the test is still SCHEDULED. After all,
-        # it might be! Who knows.
         return TestStatusInfo(
             state=STATES.SCHEDULED,
-            note="Job '{}' has unknown/unhandled job state '{}'. We have no "
-            "idea what is going on.".format(job_info["id"], job_state),
-            when=time.time(),
+            note="Job '{}' has unknown/unhandled job state '{}'. "
+                 "We have no idea what is going on.".format(job_info['id'], job_state),
+            when=time.time()
         )
 
-    def cancel(self, job_info: JobInfo) -> Optional[str]:
-        """qdel the job attached to the given test."""
-
-        _ = self
-
-        if job_info["sys_name"] != sys_vars.get_vars(True)["sys_name"]:
+    def cancel(self, job_info: JobInfo) -> Union[str, None]:
+        """Cancel the PBS job via qdel."""
+        if job_info['sys_name'] != sys_vars.get_vars(True)['sys_name']:
             return "Could not cancel - job started on a different cluster ({}).".format(
-                job_info["sys_name"]
-            )
+                job_info['sys_name'])
 
-        cmd = ["qdel", job_info["id"]]
-
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = proc.communicate()
+        proc = subprocess.Popen(
+            ['qdel', job_info['id']],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        _, stderr = proc.communicate()
 
         if proc.poll() == 0:
             return None
-        else:
-            return "Tried (but failed) to cancel job {}: {}".format(
-                job_info["id"], stderr
-            )
+        return "Tried (but failed) to cancel job {}: {}".format(job_info['id'], stderr)

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -178,9 +178,9 @@ def pbs_states(state):
         return ['UNKNOWN']
 
     # STYLE FIX: use enumerate instead of range(len(...))
-    for i, s in enumerate(states):
-        if s.endswith('$') or s.endswith('*'):
-            states[i] = s[:-1]
+    for i, state in enumerate(states):
+        if state.endswith('$') or state.endswith('*'):
+            states[i] = state[:-1]
 
     return states
 
@@ -326,20 +326,21 @@ class PBS(SchedulerPluginAdvanced):
         node_list = []
 
         try:
-            with open(nodefile, 'r') as nf:
-                n_tmp = nf.read().split('\n')
+            with open(nodefile, 'r') as nodefile_handle:
+                raw_nodes = nodefile_handle.read().split('\n')
         except OSError as err:
             raise SchedulerPluginError(
                 "Could not read PBS nodefile '{}'.".format(nodefile), prior_error=err)
 
-        for n in n_tmp:
-            if '.' in n:
-                node_list.append(n.split('.')[0])
+        for node in raw_nodes:
+            if '.' in node:
+                node_list.append(node.split('.')[0])
             else:
-                node_list.append(n)
+                node_list.append(node)
 
         return self.parse_node_list(node_list)
 
+    # pylint: disable=no-self-use  # required override of SchedulerPluginAdvanced
     def _get_raw_node_data(self, sched_config) -> Tuple[Union[List[Any], None], Any]:
         """Use `pbsnodes` to collect data on nodes."""
         try:
@@ -410,6 +411,7 @@ class PBS(SchedulerPluginAdvanced):
 
         return node_info
 
+    # pylint: disable=no-self-use  # required override of SchedulerPluginAdvanced
     def _filter_custom(self, sched_config: dict, node_name: str, node: NodeInfo) \
             -> Union[str, None]:
         """Filter nodes by features. Returns reason to filter, or None to keep."""
@@ -421,6 +423,7 @@ class PBS(SchedulerPluginAdvanced):
                 return "node not in queue"
         return None
 
+    # pylint: disable=no-self-use  # required override of SchedulerPlugin
     def _available(self) -> bool:
         """Check that PBS commands exist and PBS can talk to the scheduler DB."""
         for command in ('pbsnodes', 'qsub', 'qstat'):
@@ -463,14 +466,16 @@ class PBS(SchedulerPluginAdvanced):
             cmd.append('-l walltime={}'.format(pbs_cfg['walltime']))
 
         if pbs_cfg.get('nodes') or pbs_cfg.get('tasks'):
-            n = pbs_cfg.get('nodes', 1)
+            node_count = pbs_cfg.get('nodes', 1)
             if pbs_cfg.get('all_queue_nodes'):
-               n = self._get_queue_nodect(pbs_cfg.get('queue'), model=pbs_cfg.get('model'))
-            t = pbs_cfg.get('tasks', 1)
+                node_count = self._get_queue_nodect(pbs_cfg.get('queue'),
+                                                    model=pbs_cfg.get('model'))
+            tasks = pbs_cfg.get('tasks', 1)
             if pbs_cfg.get('target') and not pbs_cfg.get('all_queue_nodes'):
-                select = '-l select={}:ncpus={}:host={}'.format(n, t, pbs_cfg['target'])
+                select = '-l select={}:ncpus={}:host={}'.format(
+                    node_count, tasks, pbs_cfg['target'])
             else:
-                select = '-l select={}:ncpus={}'.format(n, t)
+                select = '-l select={}:ncpus={}'.format(node_count, tasks)
             # Optional: only appended when explicitly set, so clusters that don't
             # use mpiprocs get exactly the select statement they got before.
             if pbs_cfg.get('mpiprocs'):
@@ -499,12 +504,14 @@ class PBS(SchedulerPluginAdvanced):
             'sys_name': sys_name,
         })
 
-    def _pbsnodes_parse(self, section: dict) -> Dict[str, str]:
+    @staticmethod
+    def _pbsnodes_parse(section: dict) -> Dict[str, str]:
         """Parse pbsnodes JSON output into a dict."""
         # SIMPLIFICATION: dict.update({k: v}) in a loop is just dict.copy()
         return dict(section)
 
-    def _qstat(self, *args, timeout=30) -> List[Dict]:
+    @staticmethod
+    def _qstat(*args, timeout=30) -> List[Dict]:
         """Run qstat and return the parsed output.
 
         :param args: Additional args to qstat.
@@ -600,6 +607,7 @@ class PBS(SchedulerPluginAdvanced):
             when=time.time()
         )
 
+    # pylint: disable=no-self-use  # required override of SchedulerPlugin
     def cancel(self, job_info: JobInfo) -> Union[str, None]:
         """Cancel the PBS job via qdel."""
         if job_info['sys_name'] != sys_vars.get_vars(True)['sys_name']:

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -298,7 +298,8 @@ class PBS(SchedulerPluginAdvanced):
                 "Invalid pbs nodelist: '{}'".format(node_list), err
             )
 
-    def _get_raw_node_data(self, sched_config) -> Tuple[Union[List[Any], None], Any]:
+    @staticmethod
+    def _get_raw_node_data(sched_config) -> Tuple[Union[List[Any], None], Any]:
         """Use the `pbsnodes` command to collect data on nodes.
         Types are converted according to self.FIELD_TYPES."""
         try:

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -47,8 +47,7 @@ class QsubHeader(KickoffScriptHeader):
             lines.append("#PBS -A {}".format(self._sched_vars.account()))
 
         if self._sched_vars.walltime() != "":
-            walltime = "00:01:00"
-            lines.append("#PBS -l walltime={}".format(walltime))
+            lines.append("#PBS -l walltime={}".format(self._sched_vars.walltime()))
 
         # Extra Qsub arguments
         for line in self._config["pbs"]["qsub_extra"]:
@@ -91,6 +90,8 @@ class PBSVars(SchedulerVariables):
         if tasks is None:
             tasks = int(self.tasks_per_node()) * nodes
 
+        cmd = []
+
         if self._sched_config["pbs"]["mpi_cmd"] != "":
             cmd = ["mpirun"]
             cmd.extend(self.mpirun_opts())
@@ -121,7 +122,7 @@ class PBSVars(SchedulerVariables):
         return walltime
 
     @dfr_var_method
-    def queue(self) -> str:
+    def queue(self) -> Optional[str]:
         """Queue to run job in."""
 
         if self._sched_config["pbs"]["queue"] is not None:
@@ -270,7 +271,7 @@ class PBS(SchedulerPluginAdvanced):
             "walltime": "00:01:00",
             "queue": None,
             "qsub_extra": [],
-            "mpi_cmd": [],
+            "mpi_cmd": "",
         }
 
         validators = {
@@ -288,7 +289,7 @@ class PBS(SchedulerPluginAdvanced):
         return elems, validators, defaults
 
     @classmethod
-    def parse_node_list(cls, node_list: List[str]) -> NodeList:
+    def parse_node_list(cls, node_list: Union[str, List[str], None]) -> NodeList:
         """Parse a list of nodes, returning a NodeList object."""
 
         nodes = []
@@ -308,8 +309,12 @@ class PBS(SchedulerPluginAdvanced):
         node_list = []
 
         nodefile = os.environ["PBS_NODEFILE"]
-        with open(nodefile, "r") as fin:
-            node_list = fin.read().split("\n")
+
+        try:
+            with open(nodefile, "r") as fin:
+                node_list = fin.read().split("\n")
+        except OSError as err:
+            raise SchedulerPluginError(f"Could not open PBS nodefile: {nodefile}.", err)
 
         try:
             return self.parse_node_list(node_list)
@@ -399,7 +404,8 @@ class PBS(SchedulerPluginAdvanced):
 
         _ = self
 
-        pbs_config = sched_config["pbs"]
+        # For now, don't do any special filtering. We may want to revisit this later.
+        return None
 
     def _available(self) -> bool:
         """Looks for several pbs commands, and tests pbs can talk to the
@@ -510,35 +516,35 @@ class PBS(SchedulerPluginAdvanced):
 
     # Pbs status mappings
     # SCHED_WAITING - The job is still queued and waiting to start.
-    SCHED_WAITING = [
+    SCHED_WAITING = (
         "Q",
         "W",
-    ]
-    # SCHED_OK - From pavilion's perspective, these all mean Pavilion should
+    )
+    # SCHED_RUN - From pavilion's perspective, these all mean Pavilion should
     # look to the test's status file for more information.
-    SCHED_RUN = [
+    SCHED_RUN = (
         "R",
         "B",
-    ]
+    )
     # SCHED_CANCELLED - The job was cancelled. We can't expect to see more
     # from the test status, as the test probably never started.
-    SCHED_CANCELLED = [
+    SCHED_CANCELLED = (
         "E",
         "X",
-    ]
+    )
     # SCHED_ERROR - Something went wrong, but the job was running at some
     # point.
-    SCHED_ERROR = [
+    SCHED_ERROR = (
         "F",
-    ]
+    )
     # SCHED_OTHER - Pavilion shouldn't see these, and will log them when it
     # does.
-    SCHED_OTHER = [
+    SCHED_OTHER = (
         "H",
         "U",
         "S",
         "T",
-    ]
+    )
 
     def _job_status(self, pav_cfg: PavConfig, job_info: JobInfo) -> TestStatusInfo:
         """Get the current status of the PBS job for the given test."""

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -40,8 +40,6 @@ class QsubHeader(KickoffScriptHeader):
         queue = self._config['pbs']['queue']
         if queue is not None:
             lines.append('#PBS -q {}'.format(queue))
-        else:
-            lines.append('#PBS -q normal'.format(queue))
 
         # Mandatory account name
         if self._sched_vars.account():
@@ -49,7 +47,7 @@ class QsubHeader(KickoffScriptHeader):
 
         # Exclusive node allocation
         if self._config['pbs'].get('exclusive'):
-            lines.append('#PBS -l place=excl')
+            lines.append('#PBS -l place=exclhost:scatter')
 
         # Extra qsub arguments
         for line in self._config['pbs']['qsub_extra']:
@@ -198,7 +196,7 @@ class PBS(SchedulerPluginAdvanced):
             yc.StrElem(name='model',
                        help_text="Node model to target. Example: broadwell"),
             yc.StrElem(name='exclusive',
-                       help_text="Request exclusive node allocation (-l place=excl). "
+                       help_text="Request exclusive node allocation (-l place=exclhost:scatter). "
                                  "Set to 'true' to enable."),
         ]
 
@@ -302,6 +300,7 @@ class PBS(SchedulerPluginAdvanced):
             ('mem', 'mem'),
             ('state', 'states'),
             ('queue', 'partitions'),
+            ('model', 'model'),
         )
 
         for node in parsed_data:
@@ -344,13 +343,14 @@ class PBS(SchedulerPluginAdvanced):
     def _filter_custom(self, sched_config: dict, node_name: str, node: NodeInfo) \
             -> Union[str, None]:
         """Filter nodes by features. Returns reason to filter, or None to keep."""
-        if ('down' in (node.get('states') or [])) or ('offline' in (node.get('states') or [])):
-            print(node)
-            return "node unavailable"
         queue = sched_config['pbs'].get('queue')
         if queue:
-            if queue not in (node.get('partitions')): # or []):
+            if queue not in (node.get('partitions') or []):
                 return "node not in queue"
+            elif 'job-exclusive' in (node.get('states') or []):
+                return None
+        if 'free' not in (node.get('states') or []):
+            return "node unavailable"
         return None
 
     def _available(self) -> bool:
@@ -366,13 +366,17 @@ class PBS(SchedulerPluginAdvanced):
         )
         return ret == 0
 
-    def _get_queue_nodect(self, queue):
+    def _get_queue_nodect(self, queue, model=None):
         nodes = self._nodes
         nodect = 0
         for node in nodes:
+            if 'offline' in (nodes[node].get('states') or []):
+                continue
+            if 'down' in (nodes[node].get('states') or []):
+                continue
             if nodes[node]['partitions']:
                 if queue in nodes[node]['partitions']:
-                    if ('down' not in nodes[node]['states']) and ('offline' not in nodes[node]['states']):
+                    if model is None or nodes[node].get('model') == model:
                         nodect += 1
         return nodect
 
@@ -395,7 +399,7 @@ class PBS(SchedulerPluginAdvanced):
         if pbs_cfg.get('nodes') or pbs_cfg.get('tasks'):
             n = pbs_cfg.get('nodes', 1)
             if pbs_cfg.get('all_queue_nodes'):
-               n = self._get_queue_nodect(pbs_cfg.get('queue'))
+               n = self._get_queue_nodect(pbs_cfg.get('queue'), model=pbs_cfg.get('model'))
             t = pbs_cfg.get('tasks', 1)
             if pbs_cfg.get('target') and not pbs_cfg.get('all_queue_nodes'):
                 select = '-l select={}:ncpus={}:host={}'.format(n, t, pbs_cfg['target'])
@@ -407,6 +411,10 @@ class PBS(SchedulerPluginAdvanced):
 
         cmd += ['-o={}'.format(job.sched_log.as_posix()), job.kickoff_path.as_posix()]
 
+        with job.kickoff_log.open('a') as log:
+            log.write(' '.join(cmd) + '\n')
+
+        #print(cmd)
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = proc.communicate()
 

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -1,0 +1,624 @@
+# pylint: disable=too-many-lines
+"""The Pbs Scheduler Plugin."""
+
+import os
+import re
+import shutil
+import subprocess
+import time
+import json
+from typing import List, Union, Any, Tuple, Dict
+
+import hostlist
+import yaml_config as yc
+from pavilion import sys_vars
+from pavilion.jobs import Job, JobInfo
+from pavilion.status_file import STATES, TestStatusInfo
+from pavilion.types import NodeInfo, NodeList
+from pavilion.var_dict import dfr_var_method
+from ..advanced import SchedulerPluginAdvanced
+from ..config import validate_list
+from ..scheduler import KickoffScriptHeader
+from ..vars import SchedulerVariables
+from ...errors import SchedulerPluginError
+
+
+class QsubHeader(KickoffScriptHeader):
+    """Provides header information specific to qsub files for the
+    pbs kickoff script."""
+
+    def _kickoff_lines(self) -> List[str]:
+        """Get the qsub header lines."""
+
+        lines = []
+
+        # White space is discouraged in job names.
+        job_name = "__".join(self._job_name.split())
+
+        lines.append('#PBS -N "{}"'.format(job_name))
+
+        queue = self._config["pbs"]["queue"]
+        if queue is not None:
+            lines.append("#PBS -q {}".format(queue))
+
+        # Mandantory Account name
+        if self._sched_vars.account() != "":
+            lines.append("#PBS -A {}".format(self._sched_vars.account()))
+
+        if self._sched_vars.walltime() != "":
+            walltime = "00:01:00"
+            lines.append("#PBS -l walltime={}".format(walltime))
+
+        # Extra Qsub arguments
+        for line in self._config["pbs"]["qsub_extra"]:
+            lines.append("#PBS {}".format(line))
+
+        return lines
+
+
+def validate_pbs_states(states):
+    """Should be a list of strings (with no punctuation) or None."""
+
+    # We can assume that if this isn't None it's a list.
+    for state in states:
+        if not re.match("^[a-z-]*$", state):
+            raise ValueError(
+                "Invalid PBS state '{}'. PBS states should be alpha numeric"
+            )
+    return states
+
+
+class PBSVars(SchedulerVariables):
+    """Scheduler variables for the Pbs scheduler."""
+
+    def _test_cmd(self):
+        """Construct a cmd to run a process under this scheduler, with the
+        criteria specified by this test.
+        """
+        pbs_conf = self._sched_config["pbs"]
+        nodes = len(self._nodes)
+        tasks = self._sched_config["tasks"]
+
+        if tasks is None:
+            tasks = int(self.tasks_per_node()) * nodes
+
+        if self._sched_config["pbs"]["mpi_cmd"] != "":
+            # cmd: mpirun
+            cmd = ["mpirun"]
+            cmd.extend(self.mpirun_opts())
+            cmd.extend(["--host", ",".join(self._nodes.keys())])
+
+        return " ".join(cmd)
+
+    @dfr_var_method
+    def test_cmd(self):
+        """Calls the actual test command and then wraps the return with the wrapper
+        provided in the schedule section of the configuration."""
+
+        # Removes all the None values to avoid getting a TypeError while trying to
+        # join two commands
+        return " ".join(
+            filter(
+                lambda item: item is not None,
+                [self._test_cmd(), self._sched_config["wrapper"]],
+            )
+        )
+
+    @dfr_var_method
+    def walltime(self):
+        walltime = self._sched_config["pbs"]["walltime"]
+
+        return walltime
+
+    @dfr_var_method
+    def queue(self):
+        if self._sched_config["pbs"]["queue"] is not None:
+            return self._sched_config["pbs"]["queue"]
+        else:
+            return None
+
+
+def pbs_float(val):
+    """PBS 'float' values might also be 'N/A'."""
+    if val == "N/A":
+        return None
+    else:
+        return float(val)
+
+
+def pbs_int(val):
+    """PBS 'int' values might also be 'N/A'."""
+    if val == "N/A":
+        return None
+    else:
+        return int(val)
+
+
+def pbs_str(val):
+    """PBS 'str' values might also be 'N/A'."""
+    if val == "N/A":
+        return None
+    else:
+        return str(val)
+
+
+def validate_mpi(val):
+    """PBS 'str' values might also be 'N/A'."""
+    if val == "N/A":
+        return None
+    else:
+        return str(val)
+
+
+def pbs_states(state):
+    """Parse a PBS state down to something reasonable."""
+    states = state.split("+")
+
+    if not states:
+        return ["UNKNOWN"]
+
+    for i in range(len(states)):
+        state = states[i]
+        if state.endswith("$") or state.endswith("*"):
+            states[i] = state[:-1]
+
+    return states
+
+
+class PBS(SchedulerPluginAdvanced):
+    """Schedule tests with Pbs!"""
+
+    VAR_CLASS = PBSVars
+    KICKOFF_SCRIPT_HEADER_CLASS = QsubHeader
+
+    def __init__(self):
+        super().__init__("pbs", "Schedules tests via the PBS scheduler.")
+
+    JOB_SHARE_KEY_ATTRS = SchedulerPluginAdvanced.JOB_SHARE_KEY_ATTRS + [
+        "pbs.qsub_extra"
+    ]
+
+    MPI_CMD_MPIRUN = "mpirun"
+    MPIRUN_BIND_OPTS = (
+        "slot",
+        "hwthread",
+        "core",
+        "L1cache",
+        "L2cache",
+        "L3cache",
+        "socket",
+        "numa",
+        "board",
+        "node",
+    )
+
+    def _get_config_elems(self):
+
+        elems = [
+            yc.ListElem(
+                name="avail_states",
+                sub_elem=yc.StrElem(),
+                help_text="When looking for immediately available "
+                "nodes, they must be in one of these "
+                "states.",
+            ),
+            yc.ListElem(
+                name="up_states",
+                sub_elem=yc.StrElem(),
+                help_text="When looking for nodes that could be  "
+                "allocated, they must be in one of these "
+                "states.",
+            ),
+            yc.ListElem(
+                name="reserved_states",
+                sub_elem=yc.StrElem(),
+                help_text="Ignore nodes in these states, unless a reservation "
+                "was specified.",
+            ),
+            yc.ListElem(
+                name="qsub_extra",
+                sub_elem=yc.StrElem(),
+                help_text="Extra arguments to add as qsub header lines. "
+                "Example: ['--deadline now+20hours']",
+            ),
+            yc.StrElem(
+                name="walltime",
+                help_text="Walltime to add to job in PBS format." "Example: 00:01:00",
+            ),
+            yc.StrElem(
+                name="queue", help_text="Queue to run job in." "Example: normal"
+            ),
+            yc.StrElem(name="tasks"),
+            yc.StrElem(name="nodes"),
+            yc.StrElem(
+                name="mpi_cmd",
+                help_text="What command to use to start mpi jobs. If empty "
+                "mpi will not be used Options are {}.".format(self.MPI_CMD_MPIRUN),
+            ),
+        ]
+
+        defaults = {
+            "up_states": [
+                "job-exclusive",
+                "job-busy",
+                "free",
+                "busy",
+                "resv-exclusive",
+            ],
+            "avail_states": ["free"],
+            "reserved_states": ["resv-exclusive"],
+            "tasks": 1,
+            "nodes": 1,
+            "walltime": "00:01:00",
+            "queue": None,
+            "qsub_extra": [],
+            "mpi_cmd": [],
+        }
+
+        validators = {
+            "up_states": validate_pbs_states,
+            "avail_states": validate_pbs_states,
+            "reserved_states": validate_pbs_states,
+            "tasks": pbs_int,
+            "nodes": pbs_int,
+            "qsub_extra": validate_list,
+            "walltime": pbs_str,
+            "queue": pbs_str,
+            "mpi_cmd": validate_mpi,
+        }
+
+        return elems, validators, defaults
+
+    @classmethod
+    def parse_node_list(cls, node_list) -> NodeList:
+        nodes = []
+        if node_list is None or node_list == "":
+            return NodeList([])
+
+        for node in node_list:
+            if node.isalpha():
+                nodes.append(node)
+
+        return NodeList(nodes)
+
+    def _get_alloc_nodes(self, job) -> NodeList:
+        """Get the list of allocated nodes."""
+
+        _ = job
+        node_list = []
+
+        nodefile = os.environ["PBS_NODEFILE"]
+        with open(nodefile, "r") as fin:
+            node_list = fin.read().split("\n")
+
+        try:
+            return self.parse_node_list(node_list)
+        except ValueError as err:
+            raise SchedulerPluginError(
+                "Invalid pbs nodelist: '{}'".format(node_list), err
+            )
+
+    def _get_raw_node_data(self, sched_config) -> Tuple[Union[List[Any], None], Any]:
+        """Use the `pbsnodes` command to collect data on nodes.
+        Types are converted according to self.FIELD_TYPES."""
+        try:
+            output = subprocess.check_output(
+                ["pbsnodes", "-avFjson"], stderr=subprocess.PIPE
+            )
+            nodes_json = json.loads(output).get("nodes", {})
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as err:
+            raise SchedulerPluginError("Failed to get pbsnodes data", err)
+
+        raw_node_data = []
+        for node_name, data in nodes_json.items():
+            res = data.get("resources_available", {})
+            res["queue"] = data.get("queue", None)
+            res["state"] = data.get("state", "unknown")
+            raw_node_data.append({node_name: res})
+
+        return raw_node_data, {"reservations": {}}
+
+    def _transform_raw_node_data(self, sched_config, node_data, extra) -> NodeInfo:
+        """Translate the gathered data into a NodeInfo dict."""
+
+        parsed_data = self._pbsnodes_parse(node_data)
+        node_info = NodeInfo({})
+
+        for node in parsed_data:
+            for orig_key, dest_key in (
+                ("vnode", "name"),
+                ("arch", "arch"),
+                ("ncpus", "cpus"),
+                ("mem", "mem"),
+                ("state", "states"),
+                ("queue", "partitions"),
+            ):
+                node_info[dest_key] = parsed_data[node].get(orig_key)
+
+        # Split and clean up the states
+        if node_info["states"] is not None:
+            node_info["states"] = [
+                state.strip().rstrip(",") for state in node_info["states"].split(",")
+            ]
+        else:
+            node_info["states"] = None
+
+        # Convert to an integer in GBytes
+        node_info["mem"] = int(node_info["mem"][:-2]) * 1024**2
+
+        # Convert to an integer
+        node_info["cpus"] = int(node_info["cpus"])
+
+        up_states = sched_config["pbs"]["up_states"]
+        avail_states = sched_config["pbs"]["avail_states"]
+        reserved_states = sched_config["pbs"]["reserved_states"]
+        if sched_config["reservation"]:
+            up_states = up_states + reserved_states
+            avail_states = avail_states + reserved_states
+
+        node_info["up"] = all(state in up_states for state in node_info["states"])
+        node_info["available"] = all(
+            state in avail_states for state in node_info["states"]
+        )
+
+        return node_info
+
+    def _filter_custom(
+        self, sched_config: dict, node_name: str, node: NodeInfo
+    ) -> Union[str, None]:
+        """Filter nodes by features. (Returns why a node should be filtered out, or None if it
+        shouldn't be."""
+
+        _ = self
+
+        pbs_config = sched_config["pbs"]
+
+    def _available(self) -> bool:
+        """Looks for several pbs commands, and tests pbs can talk to the
+        pbs db."""
+
+        _ = self
+
+        for command in "pbsnodes", "qsub", "qstat":
+            if shutil.which(command) is None:
+                return False
+
+        # Try to get basic system info from sinfo. Should return not-zero
+        # on failure.
+        ret = subprocess.call(
+            ["qstat"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        return ret == 0
+
+    def _kickoff(
+        self,
+        pav_cfg,
+        job: Job,
+        sched_config: dict,
+        job_name: str,
+        nodes: Union[NodeList, None] = None,
+        node_range: Union[Tuple[int, int], None] = None,
+    ) -> JobInfo:
+        """Submit the kick off script using qsub."""
+
+        _ = self
+        cmd = ["qsub"]
+
+        print("Scheduler variables:")
+        print(json.dumps(sched_config["pbs"], indent=5))
+
+        if sched_config["pbs"]["walltime"]:
+            cmd.append("-l walltime={}".format(sched_config["pbs"]["walltime"]))
+
+        if sched_config["pbs"]["nodes"] or sched_config["pbs"]["tasks"]:
+            nodes = sched_config["pbs"].get("nodes", 1)
+            tasks = sched_config["pbs"].get("tasks", 1)
+            cmd.append("-l select={}:ncpus={}".format(nodes, tasks))
+
+        proc = subprocess.Popen(
+            cmd
+            + ["-o={}".format(job.sched_log.as_posix()), job.kickoff_path.as_posix()],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = proc.communicate()
+
+        if proc.poll() != 0:
+            raise SchedulerPluginError(
+                "Qsub failed for kickoff script '{}': {}".format(
+                    job.kickoff_path, stderr.decode("utf8")
+                )
+            )
+
+        sys_name = sys_vars.get_vars(True)["sys_name"]
+
+        return JobInfo(
+            {
+                "id": stdout.decode("UTF-8").strip().split(".")[0],
+                "sys_name": sys_name,
+            }
+        )
+
+    @staticmethod
+    def _pbsnodes_parse(section: str) -> Dict[str, str]:
+        # pbsnodes json output imports cleanly into dicts
+        # without modification
+
+        node_info = {}
+
+        for node in section:
+            node_info.update({node: section[node]})
+
+        return node_info
+
+    @staticmethod
+    def _qstat(*args, timeout=30) -> List[Dict]:
+        """Run qstat show and return the parsed output.
+
+        :param list(str) args: Additional args to pbsnodes.
+        :param int timeout: How long to wait for results.
+        """
+
+        cmd = ["qstat", "-fFjson"] + list(args)
+
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            raise TimeoutError("Timed out waiting for pbsnodes.")
+
+        stdout = stdout.decode("utf8")
+        stderr = stderr.decode("utf8")
+
+        if proc.poll() != 0:
+            raise ValueError(stderr)
+
+        job_dict = json.loads(stdout)["Jobs"]
+
+        results = []
+        results.append(job_dict)
+
+        return results
+
+    # Pbs status mappings
+    # SCHED_WAITING - The job is still queued and waiting to start.
+    SCHED_WAITING = [
+        "Q",
+        "W",
+    ]
+    # SCHED_OK - From pavilion's perspective, these all mean Pavilion should
+    # look to the test's status file for more information.
+    SCHED_RUN = [
+        "R",
+        "B",
+    ]
+    # SCHED_CANCELLED - The job was cancelled. We can't expect to see more
+    # from the test status, as the test probably never started.
+    SCHED_CANCELLED = [
+        "E",
+        "X",
+    ]
+    # SCHED_ERROR - Something went wrong, but the job was running at some
+    # point.
+    SCHED_ERROR = [
+        "F",
+    ]
+    # SCHED_OTHER - Pavilion shouldn't see these, and will log them when it
+    # does.
+    SCHED_OTHER = [
+        "H",
+        "U",
+        "S",
+        "T",
+    ]
+
+    def _job_status(self, pav_cfg, job_info: JobInfo) -> TestStatusInfo:
+        """Get the current status of the PBS job for the given test."""
+
+        sys_name = sys_vars.get_vars(True)["sys_name"]
+        if job_info["sys_name"] != sys_name:
+            return TestStatusInfo(
+                STATES.SCHEDULED,
+                "Job started on a different cluster ({}).".format(sys_name),
+            )
+
+        try:
+            job_data = self._qstat(job_info["id"])
+        except ValueError as err:
+            return TestStatusInfo(
+                state=STATES.SCHED_ERROR, note=str(err), when=time.time()
+            )
+        except TimeoutError:
+            return TestStatusInfo(
+                state=STATES.SCHED_WARNING,
+                note=f"Timed out waiting for pbsnodes (job {job_info['id']})",
+                when=time.time(),
+            )
+
+        if len(job_data) == 0:
+            return TestStatusInfo(
+                state=STATES.SCHED_ERROR,
+                note="Could not find job {}".format(job_info["id"]),
+                when=time.time(),
+            )
+
+        # qstat returns a list. There should only be one item in that
+        # list though.
+        if len(job_data) > 0:
+            job_data = job_data.pop(0)
+        else:
+            return TestStatusInfo(
+                state=STATES.SCHEDULED,
+                note=(
+                    "Could not find info on pbs job '{}' in pbs.".format(job_info["id"])
+                ),
+                when=time.time(),
+            )
+
+        job = " ".join(list(job_data.keys()))
+        job_state = job_data[job].get("job_state", "UNKNOWN")
+        if job_state in self.SCHED_WAITING:
+            return TestStatusInfo(
+                state=STATES.SCHEDULED,
+                note=(
+                    "Job {} has state '{}', reason '{}'".format(
+                        job_info["id"], job_state, job_info.get("Reason")
+                    )
+                ),
+                when=time.time(),
+            )
+        elif job_state in self.SCHED_RUN:
+            return TestStatusInfo(
+                state=STATES.SCHED_RUNNING,
+                note=(
+                    "Job is running or about to run. Has job state {}".format(job_state)
+                ),
+                when=time.time(),
+            )
+        elif job_state in self.SCHED_ERROR:
+            return TestStatusInfo(
+                STATES.SCHED_ERROR,
+                "The scheduler killed the job, it has job state '{}'".format(job_state),
+            )
+
+        elif job_state in self.SCHED_CANCELLED:
+            # The job appears to have been cancelled without running.
+            return TestStatusInfo(
+                STATES.SCHED_CANCELLED,
+                "Job cancelled, has job state '{}'".format(job_state),
+            )
+
+        # The best we can say is that the test is still SCHEDULED. After all,
+        # it might be! Who knows.
+        return TestStatusInfo(
+            state=STATES.SCHEDULED,
+            note="Job '{}' has unknown/unhandled job state '{}'. We have no "
+            "idea what is going on.".format(job_info["id"], job_state),
+            when=time.time(),
+        )
+
+    def cancel(self, job_info: JobInfo) -> Union[str, None]:
+        """qdel the job attached to the given test."""
+
+        _ = self
+
+        if job_info["sys_name"] != sys_vars.get_vars(True)["sys_name"]:
+            return "Could not cancel - job started on a different cluster ({}).".format(
+                job_info["sys_name"]
+            )
+
+        cmd = ["qdel", job_info["id"]]
+
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+
+        if proc.poll() == 0:
+            return None
+        else:
+            return "Tried (but failed) to cancel job {}: {}".format(
+                job_info["id"], stderr
+            )

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -318,9 +318,10 @@ class PBS(SchedulerPluginAdvanced):
                 "Invalid pbs nodelist: '{}'".format(node_list), err
             )
 
-    @staticmethod
-    def _get_raw_node_data(sched_config: Dict[str, Any]
-                            ) -> Tuple[List[Dict[str, Dict]], Dict[str, Dict]]:
+    # pylint: disable=no-self-use
+    def _get_raw_node_data(self,
+                           sched_config: Dict[str, Any]
+                          ) -> Tuple[List[Dict[str, Dict]], Dict[str, Dict]]:
         """Use the `pbsnodes` command to collect data on nodes.
         Types are converted according to self.FIELD_TYPES."""
 

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -1,0 +1,618 @@
+# pylint: disable=too-many-lines
+"""The Pbs Scheduler Plugin."""
+
+import os
+import re
+import shutil
+import subprocess
+import time
+import json
+from typing import List, Union, Any, Tuple, Dict
+
+import hostlist
+import yaml_config as yc
+from pavilion import sys_vars
+from pavilion.jobs import Job, JobInfo
+from pavilion.status_file import STATES, TestStatusInfo
+from pavilion.types import NodeInfo, NodeList
+from pavilion.var_dict import dfr_var_method
+from ..advanced import SchedulerPluginAdvanced
+from ..config import validate_list
+from ..scheduler import KickoffScriptHeader
+from ..vars import SchedulerVariables
+from ...errors import SchedulerPluginError, SchedConfigError
+
+
+class QsubHeader(KickoffScriptHeader):
+    """Provides header information specific to qsub files for the PBS kickoff script."""
+
+    def _kickoff_lines(self) -> List[str]:
+        """Get the qsub header lines."""
+
+        lines = []
+
+        # PBS job names: first char must be alphabetic, only alphanumeric/_/- allowed.
+        job_name = re.sub(r'[^a-zA-Z0-9_\-]', '_', self._job_name)
+        if not job_name or not job_name[0].isalpha():
+            job_name = 'pav_' + job_name
+        lines.append('#PBS -N {}'.format(job_name))
+
+        queue = self._config['pbs']['queue']
+        if queue is not None:
+            lines.append('#PBS -q {}'.format(queue))
+
+        # Mandatory account name
+        if self._sched_vars.account():
+            lines.append('#PBS -A {}'.format(self._sched_vars.account()))
+
+        # Exclusive node allocation
+        if self._config['pbs'].get('exclusive'):
+            lines.append('#PBS -l place=exclhost:scatter')
+
+        # Extra qsub arguments
+        for line in self._config['pbs']['qsub_extra']:
+            lines.append('#PBS {}'.format(line))
+
+        return lines
+
+
+def validate_pbs_states(states):
+    """Should be a list of strings (with no punctuation) or None."""
+    for state in states:
+        if not re.match(r'^[a-z-]*$', state):
+            raise SchedConfigError(
+                "Invalid PBS state '{}'. PBS states should be alpha numeric.".format(state))
+    return states
+
+
+class PBSVars(SchedulerVariables):
+    """Scheduler variables for the PBS scheduler."""
+
+    # 'pav show sched --vars pbs' renders this for deferred vars. Inherit upstream's
+    # examples, then correct the ones that are wrong or missing for PBS:
+    #  - srun_args is overridden below to '' for PBS, but the inherited example still
+    #    advertised Slurm flags, which is exactly the confusion the override exists
+    #    to remove.
+    #  - our own deferred vars had no example at all and rendered as '<no example>'.
+    EXAMPLE = dict(
+        SchedulerVariables.EXAMPLE,
+        srun_args='',
+        queue='workq',
+        walltime='00:01:00',
+        mpiprocs='2',
+        test_cmd='mpirun --host node01,node02',
+    )
+
+    def _test_cmd(self):
+        """Construct a cmd to run a process under this scheduler."""
+        pbs_conf = self._sched_config['pbs']
+        nodes = len(self._nodes)
+        tasks = self._sched_config['tasks']
+
+        if tasks is None:
+            tasks = int(self.tasks_per_node()) * nodes
+
+        cmd = []
+        if pbs_conf['mpi_cmd']:
+            cmd = ['mpirun']
+            cmd.extend(self.mpirun_opts())
+            cmd.extend(['--host', ','.join(self._nodes.keys())])
+
+        return ' '.join(cmd)
+
+    @dfr_var_method
+    def test_cmd(self):
+        """Calls the actual test command and wraps the return with the configured wrapper."""
+        # Filter None values to avoid TypeError when joining
+        parts = filter(None, [self._test_cmd(), self._sched_config.get('wrapper')])
+        return ' '.join(parts)
+
+    @dfr_var_method
+    def walltime(self):
+        """Return the configured walltime."""
+        return self._sched_config['pbs']['walltime']
+
+    @dfr_var_method
+    def queue(self):
+        """Return the configured queue, or empty string if not set."""
+        return self._sched_config['pbs']['queue'] or ''
+
+    # NOTE: a variable's docstring IS its help text in 'pav show sched --vars', and
+    # that column is narrow. Keep these docstrings to ONE short line; rationale
+    # belongs here in comments, which the listing never renders.
+    #
+    # Upstream's SchedulerVariables.srun_args (lib/pavilion/schedulers/vars.py)
+    # composes Slurm flags: --account, --partition, --qos, --reservation, --nodes,
+    # and its own docstring says it is meant for the 'raw' scheduler. Every plugin
+    # inherits it, so it appears under PBS whether it makes sense or not -- a PBS
+    # test referencing {{sched.srun_args}} would silently be handed Slurm flags
+    # instead of erroring. Overridden to '' so it is inert. It cannot be removed
+    # from the listing without touching pavilion source.
+    #
+    # For extra qsub arguments use the 'qsub_extra' CONFIG KEY (emits '#PBS' header
+    # lines). There is no {{sched.qsub_extra}} variable.
+    #
+    # Returns '' not None: dfr_var_method rejects None and crashes kickoff.
+    @dfr_var_method
+    def srun_args(self):
+        """Not applicable to PBS - always empty. Use the 'qsub_extra' config key."""
+
+        return ''
+
+    # Lets a test reference the rank count it asked for instead of hardcoding it
+    # twice, e.g. 'mpirun -np {{sched.mpiprocs}} ./app'. Returns '' not None when
+    # unset: mpiprocs is optional and dfr_var_method rejects a None return with
+    # "Invalid variable value returned by ...", crashing kickoff -- same reason
+    # queue() returns ''. Docstring stays one line: it is the --vars help text.
+    @dfr_var_method
+    def mpiprocs(self):
+        """The configured MPI ranks per chunk, or '' if not set."""
+        mpiprocs = self._sched_config['pbs'].get('mpiprocs')
+
+        return str(mpiprocs) if mpiprocs else ''
+
+
+def pbs_float(val):
+    """PBS 'float' values might also be 'N/A'."""
+    return None if val == 'N/A' else float(val)
+
+
+def pbs_int(val):
+    """PBS 'int' values might also be 'N/A'."""
+    return None if val == 'N/A' else int(val)
+
+
+def pbs_str(val):
+    """PBS 'str' values might also be 'N/A'."""
+    return None if val == 'N/A' else str(val)
+
+
+
+
+
+def pbs_states(state):
+    """Parse a PBS state down to something reasonable."""
+    states = state.split('+')
+
+    if not states:
+        return ['UNKNOWN']
+
+    # STYLE FIX: use enumerate instead of range(len(...))
+    for i, s in enumerate(states):
+        if s.endswith('$') or s.endswith('*'):
+            states[i] = s[:-1]
+
+    return states
+
+
+
+class PBS(SchedulerPluginAdvanced):
+    """Schedule tests with PBS!"""
+
+    VAR_CLASS = PBSVars
+    KICKOFF_SCRIPT_HEADER_CLASS = QsubHeader
+
+    # Pbs status mappings
+    SCHED_WAITING = ['Q', 'W']
+    SCHED_RUN = ['R', 'B']
+    SCHED_CANCELLED = ['E', 'X']
+    SCHED_ERROR = ['F']
+    SCHED_OTHER = ['H', 'U', 'S', 'T']
+
+    def __init__(self):
+        super().__init__('pbs', "Schedules tests via the PBS scheduler.")
+
+    # Tests may only share a PBS allocation when every setting that shapes the qsub
+    # command matches. Anything listed here that differs forces separate jobs.
+    # If an option that changes the select statement or qsub args is NOT listed,
+    # Pavilion will merge those tests into one allocation and one of them silently
+    # gets the other's resources -- which is exactly what happened with mpiprocs
+    # before it was added here.
+    JOB_SHARE_KEY_ATTRS = SchedulerPluginAdvanced.JOB_SHARE_KEY_ATTRS + [
+        'pbs.qsub_extra',
+        'pbs.exclusive',
+        'pbs.mpiprocs',
+    ]
+
+    MPI_CMD_MPIRUN = 'mpirun'
+    MPIRUN_BIND_OPTS = (
+        'slot', 'hwthread', 'core', 'L1cache', 'L2cache', 'L3cache',
+        'socket', 'numa', 'board', 'node'
+    )
+
+    def _get_config_elems(self):
+        elems = [
+            yc.ListElem(name='avail_states',
+                        sub_elem=yc.StrElem(),
+                        help_text="When looking for immediately available nodes, "
+                                  "they must be in one of these states."),
+            yc.ListElem(name='up_states',
+                        sub_elem=yc.StrElem(),
+                        help_text="When looking for nodes that could be allocated, "
+                                  "they must be in one of these states."),
+            yc.StrElem(name='all_queue_nodes',
+                       help_text="If set, use all nodes in the queue instead of a fixed count."),
+            yc.ListElem(name='reserved_states',
+                        sub_elem=yc.StrElem(),
+                        help_text="Ignore nodes in these states, unless a reservation "
+                                  "was specified."),
+            yc.ListElem(name='qsub_extra',
+                        sub_elem=yc.StrElem(),
+                        help_text="Extra arguments to add as qsub header lines. "
+                                  "Example: ['--deadline now+20hours']"),
+            yc.StrElem(name='walltime',
+                       help_text="Walltime to add to job in PBS format. "
+                                 "Example: 00:01:00"),
+            yc.StrElem(name='target',
+                       help_text="Target a specific host. "
+                                 "Example: node001 "),
+            yc.StrElem(name='queue',
+                       help_text="Queue to run job in. Example: normal"),
+            yc.StrElem(name='tasks'),
+            yc.StrElem(name='nodes'),
+            yc.StrElem(name='mpiprocs',
+                       help_text="MPI ranks per chunk, added to the select statement as "
+                                 "'-l select=...:mpiprocs=N'. OPTIONAL and unset by default -- "
+                                 "some clusters require it, others don't, and when it is unset "
+                                 "the select statement is byte-for-byte what it was before. "
+                                 "Note this is distinct from 'tasks', which sets ncpus (cores "
+                                 "per chunk); mpiprocs is what determines the PBS_NODEFILE line "
+                                 "count and the rank count mpirun sees. Example: 2"),
+            yc.StrElem(name='mpi_cmd',
+                       help_text="Command to use to start MPI jobs. If empty, "
+                                 "MPI will not be used. Options: {}.".format(self.MPI_CMD_MPIRUN)),
+            yc.StrElem(name='model',
+                       help_text="Node model to target. Example: broadwell"),
+            yc.StrElem(name='exclusive',
+                       help_text="Request exclusive node allocation (-l place=exclhost:scatter). "
+                                 "Set to 'true' to enable."),
+        ]
+
+        defaults = {
+            'up_states': ['job-exclusive', 'job-busy', 'free', 'busy', 'resv-exclusive'],
+            'avail_states': ['free'],
+            'reserved_states': ['resv-exclusive'],
+            'tasks': 1,
+            'nodes': 1,
+            'walltime': '00:01:00',
+            'queue': None,
+            'qsub_extra': [],
+            'mpi_cmd': [],
+            'target': None,
+            'all_queue_nodes': None,
+            'mpiprocs': None,
+            'model': None,
+            'exclusive': None,
+        }
+
+        validators = {
+            'up_states': validate_pbs_states,
+            'avail_states': validate_pbs_states,
+            'reserved_states': validate_pbs_states,
+            'tasks': pbs_int,
+            'nodes': pbs_int,
+            'qsub_extra': validate_list,
+            'walltime': pbs_str,
+            'queue': pbs_str,
+            'mpi_cmd': pbs_str,
+            'target': pbs_str,
+            'all_queue_nodes': pbs_int,
+            'mpiprocs': pbs_int,
+            'model': pbs_str,
+            'exclusive': lambda v: v if v is None else str(v).lower() in ('true', '1', 'yes'),
+        }
+
+        return elems, validators, defaults
+
+    @classmethod
+    def parse_node_list(cls, node_list) -> NodeList:
+        if not node_list:
+            return NodeList([])
+
+        # BUG FIX: isalpha() rejects hostnames with digits/hyphens; use a truthy check instead
+        # Deduplicate while preserving order: PBS_NODEFILE lists one entry per CPU slot,
+        # so a node with 2 CPUs appears twice. dict.fromkeys preserves insertion order.
+        nodes = list(dict.fromkeys(n for n in node_list if n))
+        return NodeList(nodes)
+
+
+    def _get_alloc_nodes(self, job) -> NodeList:
+        """Get the list of allocated nodes."""
+        try:
+            nodefile = os.environ['PBS_NODEFILE']
+        except KeyError:
+            raise SchedulerPluginError("PBS_NODEFILE environment variable is not set.")
+
+        node_list = []
+
+        try:
+            with open(nodefile, 'r') as nf:
+                n_tmp = nf.read().split('\n')
+        except OSError as err:
+            raise SchedulerPluginError(
+                "Could not read PBS nodefile '{}'.".format(nodefile), prior_error=err)
+
+        for n in n_tmp:
+            if '.' in n:
+                node_list.append(n.split('.')[0])
+            else:
+                node_list.append(n)
+
+        return self.parse_node_list(node_list)
+
+    def _get_raw_node_data(self, sched_config) -> Tuple[Union[List[Any], None], Any]:
+        """Use `pbsnodes` to collect data on nodes."""
+        try:
+            output = subprocess.check_output(['pbsnodes', '-avFjson'], stderr=subprocess.PIPE)
+            nodes_json = json.loads(output).get('nodes', {})
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as err:
+            raise SchedulerPluginError("Failed to get pbsnodes data", err)
+
+        raw_node_data = []
+        for node_name, data in nodes_json.items():
+            res = data.get('resources_available', {})
+            queue = data.get('queue')
+            res['queue'] = [queue] if queue else []
+            res['state'] = data.get('state', 'unknown')
+            raw_node_data.append({node_name: res})
+
+        return raw_node_data, {'reservations': {}}
+
+    def _transform_raw_node_data(self, sched_config, node_data, extra) -> NodeInfo:
+        """Translate gathered data into a NodeInfo dict."""
+        parsed_data = self._pbsnodes_parse(node_data)
+        node_info = NodeInfo({})
+
+        key_map = (
+            ('vnode', 'name'),
+            ('arch', 'arch'),
+            ('ncpus', 'cpus'),
+            ('mem', 'mem'),
+            ('state', 'states'),
+            ('queue', 'partitions'),
+            ('model', 'model'),
+        )
+
+        for node in parsed_data:
+            for orig_key, dest_key in key_map:
+                node_info[dest_key] = parsed_data[node].get(orig_key)
+
+        # Split and clean up states
+        if node_info['states'] is not None:
+            node_info['states'] = [
+                state.strip().rstrip(',') for state in node_info['states'].split(',')
+            ]
+
+        # Convert mem to bytes; PBS reports values like '4194304kb'
+        if node_info.get('mem'):
+            mem_str = node_info['mem']
+            suffix = mem_str[-2:].lower()
+            value = int(mem_str[:-2])
+            multipliers = {'kb': 1024, 'mb': 1024 ** 2, 'gb': 1024 ** 3}
+            node_info['mem'] = value * multipliers.get(suffix, 1)
+
+        # Convert cpus to integer
+        if node_info.get('cpus'):
+            node_info['cpus'] = int(node_info['cpus'])
+
+        pbs_config = sched_config['pbs']
+        up_states = list(pbs_config['up_states'])
+        avail_states = list(pbs_config['avail_states'])
+        reserved_states = pbs_config['reserved_states']
+
+        if sched_config.get('reservation'):
+            up_states += reserved_states
+            avail_states += reserved_states
+
+        states = node_info.get('states') or []
+        node_info['up'] = all(state in up_states for state in states)
+        node_info['available'] = all(state in avail_states for state in states)
+
+        return node_info
+
+    def _filter_custom(self, sched_config: dict, node_name: str, node: NodeInfo) \
+            -> Union[str, None]:
+        """Filter nodes by features. Returns reason to filter, or None to keep."""
+        if 'free' not in (node.get('states') or []):
+            return "node unavailable"
+        queue = sched_config['pbs'].get('queue')
+        if queue:
+            if queue not in (node.get('partitions') or []):
+                return "node not in queue"
+        return None
+
+    def _available(self) -> bool:
+        """Check that PBS commands exist and PBS can talk to the scheduler DB."""
+        for command in ('pbsnodes', 'qsub', 'qstat'):
+            if shutil.which(command) is None:
+                return False
+
+        ret = subprocess.call(
+            ['qstat'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return ret == 0
+
+    def _get_queue_nodect(self, queue, model=None):
+        nodes = self._nodes
+        nodect = 0
+        for node in nodes:
+            if 'free' not in (nodes[node].get('states') or []):
+                continue
+            if nodes[node]['partitions']:
+                if queue in nodes[node]['partitions']:
+                    if model is None or nodes[node].get('model') == model:
+                        nodect += 1
+        return nodect
+
+    def _kickoff(self, pav_cfg, job: Job, sched_config: dict, job_name: str,
+                 nodes: Union[NodeList, None] = None,
+                 node_range: Union[Tuple[int, int], None] = None) -> JobInfo:
+        """Submit the kickoff script using qsub."""
+
+        pbs_cfg = sched_config['pbs']
+        cmd = ['qsub']
+
+        if pbs_cfg.get('all_queue_nodes') and pbs_cfg.get('target'):
+            raise SchedulerPluginError(
+                "PBS config error: 'all_queue_nodes' and 'target' are mutually exclusive. "
+                "Remove one before submitting.")
+
+        if pbs_cfg.get('walltime'):
+            cmd.append('-l walltime={}'.format(pbs_cfg['walltime']))
+
+        if pbs_cfg.get('nodes') or pbs_cfg.get('tasks'):
+            n = pbs_cfg.get('nodes', 1)
+            if pbs_cfg.get('all_queue_nodes'):
+               n = self._get_queue_nodect(pbs_cfg.get('queue'), model=pbs_cfg.get('model'))
+            t = pbs_cfg.get('tasks', 1)
+            if pbs_cfg.get('target') and not pbs_cfg.get('all_queue_nodes'):
+                select = '-l select={}:ncpus={}:host={}'.format(n, t, pbs_cfg['target'])
+            else:
+                select = '-l select={}:ncpus={}'.format(n, t)
+            # Optional: only appended when explicitly set, so clusters that don't
+            # use mpiprocs get exactly the select statement they got before.
+            if pbs_cfg.get('mpiprocs'):
+                select += ':mpiprocs={}'.format(pbs_cfg['mpiprocs'])
+            if pbs_cfg.get('model'):
+                select += ':model={}'.format(pbs_cfg['model'])
+            cmd.append(select)
+
+        cmd += ['-o', job.sched_log.as_posix(), job.kickoff_path.as_posix()]
+
+        with job.kickoff_log.open('a') as log:
+            log.write(' '.join(cmd) + '\n')
+
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+
+        if proc.poll() != 0:
+            raise SchedulerPluginError(
+                "Qsub failed for kickoff script '{}': {}"
+                .format(job.kickoff_path, stderr.decode('utf8'))
+            )
+
+        sys_name = sys_vars.get_vars(True)['sys_name']
+        return JobInfo({
+            'id': stdout.decode('utf-8').strip().split('.')[0],
+            'sys_name': sys_name,
+        })
+
+    def _pbsnodes_parse(self, section: dict) -> Dict[str, str]:
+        """Parse pbsnodes JSON output into a dict."""
+        # SIMPLIFICATION: dict.update({k: v}) in a loop is just dict.copy()
+        return dict(section)
+
+    def _qstat(self, *args, timeout=30) -> List[Dict]:
+        """Run qstat and return the parsed output.
+
+        :param args: Additional args to qstat.
+        :param timeout: How long to wait for results (seconds).
+        """
+        cmd = ['qstat', '-fFjson'] + list(args)
+
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired as err:
+            raise SchedulerPluginError("Timed out waiting for qstat.", prior_error=err)
+
+        stdout = stdout.decode('utf-8')
+        stderr = stderr.decode('utf-8')
+
+        if proc.poll() != 0:
+            raise SchedulerPluginError("qstat failed: {}".format(stderr))
+
+        try:
+            job_dict = json.loads(stdout)['Jobs']
+        except json.JSONDecodeError as err:
+            raise SchedulerPluginError(
+                "Could not parse qstat output as JSON.", prior_error=err)
+        except KeyError:
+            raise SchedulerPluginError(
+                "qstat JSON output missing 'Jobs' key.")
+
+        return [job_dict]
+
+    def _job_status(self, pav_cfg, job_info: JobInfo) -> TestStatusInfo:
+        """Get the current status of the PBS job."""
+        sys_name = sys_vars.get_vars(True)['sys_name']
+        if job_info['sys_name'] != sys_name:
+            return TestStatusInfo(
+                STATES.SCHEDULED,
+                "Job started on a different cluster ({}).".format(sys_name)
+            )
+
+        try:
+            job_data = self._qstat(job_info['id'])
+        except SchedulerPluginError as err:
+            if isinstance(err.prior_error, subprocess.TimeoutExpired):
+                return TestStatusInfo(
+                    state=STATES.SCHED_WARNING,
+                    note="Timed out waiting for qstat (job {})".format(job_info['id']),
+                    when=time.time()
+                )
+            return TestStatusInfo(state=STATES.SCHED_ERROR, note=str(err), when=time.time())
+
+        if not job_data:
+            return TestStatusInfo(
+                state=STATES.SCHED_ERROR,
+                note="Could not find job {}".format(job_info['id']),
+                when=time.time()
+            )
+
+        # BUG FIX: original code checked len > 0 twice, with dead code in the else branch
+        job_data = job_data.pop(0)
+
+        job_id = list(job_data.keys())[0]
+        job_state = job_data[job_id].get('job_state', 'UNKNOWN')
+
+        if job_state in self.SCHED_WAITING:
+            return TestStatusInfo(
+                state=STATES.SCHEDULED,
+                note="Job {} has state '{}', reason '{}'".format(
+                    job_info['id'], job_state, job_info.get('Reason')),
+                when=time.time()
+            )
+        elif job_state in self.SCHED_RUN:
+            return TestStatusInfo(
+                state=STATES.SCHED_RUNNING,
+                note="Job is running or about to run. Has job state {}".format(job_state),
+                when=time.time()
+            )
+        elif job_state in self.SCHED_ERROR:
+            return TestStatusInfo(
+                STATES.SCHED_ERROR,
+                "The scheduler killed the job, it has job state '{}'".format(job_state)
+            )
+        elif job_state in self.SCHED_CANCELLED:
+            return TestStatusInfo(
+                STATES.SCHED_CANCELLED,
+                "Job cancelled, has job state '{}'".format(job_state)
+            )
+
+        return TestStatusInfo(
+            state=STATES.SCHEDULED,
+            note="Job '{}' has unknown/unhandled job state '{}'. "
+                 "We have no idea what is going on.".format(job_info['id'], job_state),
+            when=time.time()
+        )
+
+    def cancel(self, job_info: JobInfo) -> Union[str, None]:
+        """Cancel the PBS job via qdel."""
+        if job_info['sys_name'] != sys_vars.get_vars(True)['sys_name']:
+            return "Could not cancel - job started on a different cluster ({}).".format(
+                job_info['sys_name'])
+
+        proc = subprocess.Popen(
+            ['qdel', job_info['id']],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        _, stderr = proc.communicate()
+
+        if proc.poll() == 0:
+            return None
+        return "Tried (but failed) to cancel job {}: {}".format(job_info['id'], stderr)

--- a/lib/pavilion/schedulers/plugins/pbs.py
+++ b/lib/pavilion/schedulers/plugins/pbs.py
@@ -113,7 +113,7 @@ class PBSVars(SchedulerVariables):
         )
 
     @dfr_var_method
-    def walltime(self):
+    def walltime(self) -> str:
         """Walltime to add to job in PBS format."""
 
         walltime = self._sched_config["pbs"]["walltime"]
@@ -121,7 +121,7 @@ class PBSVars(SchedulerVariables):
         return walltime
 
     @dfr_var_method
-    def queue(self):
+    def queue(self) -> str:
         """Queue to run job in."""
 
         if self._sched_config["pbs"]["queue"] is not None:

--- a/test/tests/pbs_sched_tests.py
+++ b/test/tests/pbs_sched_tests.py
@@ -1,0 +1,279 @@
+"""Unit tests for the PBS scheduler plugin.
+
+These deliberately exercise only logic that runs without a live PBS cluster, so
+they are safe in CI: scheduler variables, node list parsing, raw node data
+transformation, qsub header generation, and config validators.
+"""
+
+import copy
+
+import pavilion.schedulers
+from pavilion.errors import SchedConfigError
+from pavilion.schedulers.plugins.pbs import (PBS, PBSVars, QsubHeader, pbs_float,
+                                             pbs_int, pbs_str, pbs_states,
+                                             validate_pbs_states)
+from pavilion.types import Nodes
+from pavilion.unittest import PavTestCase
+
+
+class PBSSchedTests(PavTestCase):
+    """Tests for the PBS scheduler plugin that need no PBS installation."""
+
+    # NOTE: PBS.get_initial_vars() shells out to 'pbsnodes' to build a node
+    # inventory, so it cannot be used in CI. Instead build a normal (raw) test to
+    # get a fully validated 'schedule' config, adjust its 'pbs' subsection, and
+    # instantiate the variable class directly -- the same approach
+    # sched_tests.SchedTests._check_examples uses to cover every scheduler.
+
+    def _pbs_config(self, **pbs_opts):
+        """Return a validated schedule config with 'schedule.pbs' options applied."""
+
+        test = self._quick_test()
+        config = copy.deepcopy(test.config['schedule'])
+        config['pbs'].update(pbs_opts)
+
+        return config
+
+    def _pbs_vars(self, **pbs_opts):
+        """Build PBS scheduler variables without needing a PBS installation."""
+
+        # deferred=False so dfr_var_method values resolve to real values rather
+        # than DeferredVariable placeholders.
+        return PBSVars(self._pbs_config(**pbs_opts), nodes=Nodes({}), chunks=[],
+                       node_list_id=0, deferred=False)
+
+    def test_plugin_is_registered(self):
+        """The PBS plugin should be available as a builtin scheduler."""
+
+        self.assertIn('pbs', pavilion.schedulers.list_plugins())
+
+        pbs_sched = pavilion.schedulers.get_plugin('pbs')
+        self.assertIsInstance(pbs_sched, PBS)
+
+    def test_queue_var_empty_when_unset(self):
+        """queue() must return '' rather than None when no queue is configured.
+
+        Pavilion's dfr_var_method rejects a None return value, which crashes job
+        kickoff, so the empty string is the correct 'no queue' sentinel.
+        """
+
+        sched_vars = self._pbs_vars()
+
+        self.assertEqual(sched_vars['queue'], '')
+        self.assertIsNotNone(sched_vars['queue'])
+
+    def test_queue_var_set(self):
+        """queue() should return the configured queue."""
+
+        self.assertEqual(self._pbs_vars(queue='workq')['queue'], 'workq')
+
+    def test_mpiprocs_var(self):
+        """mpiprocs() returns '' when unset and the value when set.
+
+        mpiprocs is optional -- some clusters require it in the select statement
+        and others reject it -- so the unset case must not produce None.
+        """
+
+        self.assertEqual(self._pbs_vars()['mpiprocs'], '')
+        self.assertEqual(self._pbs_vars(mpiprocs='2')['mpiprocs'], '2')
+
+    def test_srun_args_is_inert(self):
+        """srun_args is a Slurm concept and must be empty under PBS.
+
+        It is inherited from SchedulerVariables, so without an override a PBS test
+        referencing {{sched.srun_args}} would silently receive Slurm flags.
+        """
+
+        self.assertEqual(self._pbs_vars(queue='workq')['srun_args'], '')
+
+    def test_walltime_var(self):
+        """walltime() should return the configured walltime."""
+
+        self.assertEqual(self._pbs_vars(walltime='00:05:00')['walltime'], '00:05:00')
+
+    def test_parse_node_list(self):
+        """PBS_NODEFILE lists one entry per task slot; nodes must be deduplicated.
+
+        Order must be preserved, and hostnames containing digits or hyphens must
+        survive (an earlier implementation used isalpha() and dropped them).
+        """
+
+        self.assertEqual(PBS.parse_node_list([]), [])
+        self.assertEqual(PBS.parse_node_list(None), [])
+
+        # One entry per CPU slot collapses to unique nodes, order preserved.
+        self.assertEqual(
+            PBS.parse_node_list(['node02', 'node02', 'node01', 'node01']),
+            ['node02', 'node01'])
+
+        # Hostnames with digits and hyphens are valid and must be kept.
+        self.assertEqual(
+            PBS.parse_node_list(['x1002c6s2b0n1', 'x1002c6s2b0n1', 'nid-00123']),
+            ['x1002c6s2b0n1', 'nid-00123'])
+
+        # Empty entries are dropped.
+        self.assertEqual(PBS.parse_node_list(['node01', '', 'node02']),
+                         ['node01', 'node02'])
+
+    def test_pbs_value_converters(self):
+        """PBS reports unavailable values as the literal string 'N/A'."""
+
+        self.assertIsNone(pbs_int('N/A'))
+        self.assertIsNone(pbs_str('N/A'))
+        self.assertIsNone(pbs_float('N/A'))
+
+        self.assertEqual(pbs_int('4'), 4)
+        self.assertEqual(pbs_str('free'), 'free')
+        self.assertEqual(pbs_float('1.5'), 1.5)
+
+    def test_pbs_states_parsing(self):
+        """Compound PBS states are '+' separated and may carry a trailing marker."""
+
+        self.assertEqual(pbs_states('free'), ['free'])
+        self.assertEqual(pbs_states('job-busy+free'), ['job-busy', 'free'])
+
+        # Trailing '*' and '$' markers are stripped.
+        self.assertEqual(pbs_states('free*'), ['free'])
+        self.assertEqual(pbs_states('busy$'), ['busy'])
+
+    def test_validate_pbs_states(self):
+        """State config values must be lowercase alphabetic, optionally hyphenated."""
+
+        states = ['free', 'job-busy', 'resv-exclusive']
+        self.assertEqual(validate_pbs_states(states), states)
+
+        with self.assertRaises(SchedConfigError):
+            validate_pbs_states(['Free'])
+
+        with self.assertRaises(SchedConfigError):
+            validate_pbs_states(['free!'])
+
+    def test_config_defaults(self):
+        """The pbs config section should supply sane defaults."""
+
+        pbs_sched = pavilion.schedulers.get_plugin('pbs')
+        _elems, _validators, defaults = pbs_sched._get_config_elems()
+
+        self.assertEqual(defaults['nodes'], 1)
+        self.assertEqual(defaults['tasks'], 1)
+        self.assertEqual(defaults['walltime'], '00:01:00')
+        self.assertEqual(defaults['avail_states'], ['free'])
+
+        # Optional keys must default to unset, so they are omitted entirely from
+        # the qsub command on clusters that do not use them.
+        for key in ('queue', 'target', 'model', 'exclusive', 'mpiprocs',
+                    'all_queue_nodes'):
+            self.assertIsNone(defaults[key],
+                              msg="'{}' must default to None (unset)".format(key))
+
+    def test_mpiprocs_affects_job_sharing(self):
+        """Tests differing in mpiprocs must not share an allocation.
+
+        Anything that changes the qsub command has to be part of the job share
+        key, or Pavilion merges those tests into one job and one of them silently
+        receives the other's resources.
+        """
+
+        self.assertIn('pbs.mpiprocs', PBS.JOB_SHARE_KEY_ATTRS)
+        self.assertIn('pbs.exclusive', PBS.JOB_SHARE_KEY_ATTRS)
+        self.assertIn('pbs.qsub_extra', PBS.JOB_SHARE_KEY_ATTRS)
+
+    def test_transform_raw_node_data(self):
+        """pbsnodes output should map onto Pavilion's NodeInfo fields."""
+
+        pbs_sched = pavilion.schedulers.get_plugin('pbs')
+        sched_config = {'pbs': {'avail_states': ['free'],
+                                'up_states': ['free', 'job-busy'],
+                                'reserved_states': ['resv-exclusive']}}
+
+        node_data = {
+            'node01': {
+                'vnode': 'node01',
+                'arch': 'linux',
+                'state': 'free',
+                'ncpus': '4',
+                'mem': '4194304kb',
+                'queue': 'workq',
+            }
+        }
+
+        node_info = pbs_sched._transform_raw_node_data(sched_config, node_data, {})
+
+        self.assertIsInstance(node_info, dict)
+        self.assertEqual(node_info['name'], 'node01')
+        self.assertEqual(node_info['cpus'], 4)
+        self.assertEqual(node_info['mem'], 4194304 * 1024)
+        self.assertEqual(node_info['states'], ['free'])
+        self.assertTrue(node_info['up'])
+        self.assertTrue(node_info['available'])
+
+    def test_transform_raw_node_data_down_node(self):
+        """A node in a state outside up_states must not be reported as up."""
+
+        pbs_sched = pavilion.schedulers.get_plugin('pbs')
+        sched_config = {'pbs': {'avail_states': ['free'],
+                                'up_states': ['free', 'job-busy'],
+                                'reserved_states': ['resv-exclusive']}}
+
+        node_data = {'node02': {'vnode': 'node02', 'state': 'down', 'ncpus': '4'}}
+
+        node_info = pbs_sched._transform_raw_node_data(sched_config, node_data, {})
+
+        self.assertFalse(node_info['up'])
+        self.assertFalse(node_info['available'])
+
+    def test_transform_raw_node_data_busy_node(self):
+        """A job-busy node is 'up' but not 'available'."""
+
+        pbs_sched = pavilion.schedulers.get_plugin('pbs')
+        sched_config = {'pbs': {'avail_states': ['free'],
+                                'up_states': ['free', 'job-busy'],
+                                'reserved_states': ['resv-exclusive']}}
+
+        node_data = {'node03': {'vnode': 'node03', 'state': 'job-busy',
+                                'ncpus': '4'}}
+
+        node_info = pbs_sched._transform_raw_node_data(sched_config, node_data, {})
+
+        self.assertTrue(node_info['up'])
+        self.assertFalse(node_info['available'])
+
+    def _qsub_lines(self, job_name='pav_test', **pbs_opts):
+        """Render the qsub header lines for the given pbs config."""
+
+        config = self._pbs_config(**pbs_opts)
+        sched_vars = PBSVars(config, nodes=Nodes({}), chunks=[], node_list_id=0,
+                             deferred=False)
+
+        header = QsubHeader(job_name, config, sched_vars,
+                            nodes=None, node_range=(1, 1))
+
+        return header._kickoff_lines()
+
+    def test_qsub_header_job_name_sanitized(self):
+        """PBS job names must start with a letter and be alphanumeric/_/- only."""
+
+        lines = self._qsub_lines(job_name='suite.test-1')
+        self.assertIn('#PBS -N suite_test-1', lines)
+
+        # A name starting with a non-letter gets a 'pav_' prefix.
+        lines = self._qsub_lines(job_name='1bad')
+        self.assertIn('#PBS -N pav_1bad', lines)
+
+    def test_qsub_header_queue_and_extra(self):
+        """Queue and qsub_extra should be emitted as header lines."""
+
+        lines = self._qsub_lines(queue='workq',
+                                 qsub_extra=['-l foo=bar'])
+
+        self.assertIn('#PBS -q workq', lines)
+        self.assertIn('#PBS -l foo=bar', lines)
+
+    def test_qsub_header_exclusive(self):
+        """'exclusive' should request exclusive host placement."""
+
+        self.assertIn('#PBS -l place=exclhost:scatter',
+                      self._qsub_lines(exclusive='true'))
+
+        self.assertNotIn('#PBS -l place=exclhost:scatter',
+                         self._qsub_lines())

--- a/test/tests/show_cmd_tests.py
+++ b/test/tests/show_cmd_tests.py
@@ -9,6 +9,7 @@ from pavilion import arguments
 from pavilion import plugins
 from pavilion import commands
 from pavilion import config
+from pavilion import schedulers
 
 
 class ShowTests(unittest.PavTestCase):
@@ -2706,4 +2707,11 @@ class ShowTests(unittest.PavTestCase):
             check=True
         )
 
-        self.assertEqual(int(lines.stdout.strip()), 4, msg=f'Expected 4 lines of output from pav show schedulers --format list. Output:\n{output}')
+        # One line per registered scheduler plugin, and no header. Derived rather
+        # than hardcoded so that adding a scheduler plugin doesn't break this test.
+        expected_lines = len(schedulers.list_plugins())
+
+        self.assertEqual(
+            int(lines.stdout.strip()), expected_lines,
+            msg=f'Expected {expected_lines} lines of output (one per scheduler, no '
+                f'header) from pav show schedulers --format list. Output:\n{output}')


### PR DESCRIPTION
Adds a scheduler plugin for PBS/OpenPBS.

Supersedes #928, which I wasn't able to update. Background discussion in #922.

Jobs are submitted with `qsub`; node inventory comes from `pbsnodes`, status from
`qstat`, and cancellation from `qdel`. The select statement is built as:

    -l select=<nodes>:ncpus=<tasks>[:host=][:mpiprocs=][:model=]

### Notes for review

**`mpiprocs` is optional and unset by default.** Some sites require it in the
select statement and others reject it, so when it isn't set it's omitted
entirely and the submitted select statement is unchanged. Worth noting `tasks`
maps to `ncpus` (cores per chunk), which is a different resource from
`mpiprocs` (ranks per chunk) — the latter is what determines the number of
lines in `$PBS_NODEFILE` and therefore the rank count `mpirun` sees.

**Scheduler variables return `''` rather than `None` when unset.** Pavilion's
`dfr_var_method` rejects a `None` return and crashes kickoff, so the empty
string is the correct "not set" sentinel.

**`srun_args` is overridden to `''`.** It's inherited from
`SchedulerVariables` and composes Slurm flags (`--account`, `--partition`,
`--qos`, ...). Without the override, a PBS test referencing
`{{sched.srun_args}}` would silently be handed Slurm arguments instead of
getting an error.

**This PR modifies one unrelated test.** `test_show_format_list_parsable` in
`show_cmd_tests.py` asserted a hardcoded count of 4 schedulers, so registering
any new scheduler breaks it. It now derives the expected count from
`len(schedulers.list_plugins())`, which keeps the real assertions intact (one
line per scheduler, no header) without breaking again the next time a scheduler
is added. Verified passing both with this plugin registered (5) and on an
unmodified `develop` checkout (4). Happy to split that into its own PR if you'd
prefer it separate.

### Testing

`test/tests/pbs_sched_tests.py` adds 18 unit tests covering scheduler
variables, `PBS_NODEFILE` parsing and deduplication, node data transformation
across free/busy/down states, qsub header generation, value converters, state
validation and config defaults.

None of them invoke `pbsnodes`/`qstat`/`qsub`, so they run on a CI runner with
no PBS installed. That means CI covers the plugin's logic; job submission
itself was verified separately against a real PBS cluster, including select
statement contents checked against the PBS accounting log.

CI is green on Python 3.6, 3.10 and 3.12.

---





Code review checklist:

- [x] Code is generally sensical and well commented
- [x] Variable/function names all telegraph their purpose and contents
- [x] Functions/classes have useful doc strings
- [x] Function arguments are typed
- [x] Added/modified unit tests to cover changes.
- [x] New features have documentation added to the docs.
- [x] New features and backwards compatibility breaks are noted in the RELEASE.md
