### PR TITLE
Fix skipped result logging when any test in a series fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Pavilion will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a bug which caused writing a series' result log to be skipped entirely, including for
+successful tests, if any tests in that series failed.
+
 ## [2.6.2] - 2026-08-25
 
 ### Added

--- a/lib/pavilion/commands/run.py
+++ b/lib/pavilion/commands/run.py
@@ -212,21 +212,21 @@ class RunCommand(Command):
             self.last_tests = list(series_obj.tests.values())
             output.fprint(self.errfile, err, color=output.RED)
             return errno.EAGAIN
+        finally:
+            if log_results:
+                try:
+                    series_obj.log_results()
+                except TestSeriesError as err:
+                    output.fprint(self.errfile, f"Error staring result logging process: {err}")
 
-        if log_results:
-            try:
-                series_obj.log_results()
-            except TestSeriesError as err:
-                output.fprint(self.errfile, f"Error staring result logging process: {err}")
+            if report_status:
+                print_from_tests(
+                    pav_cfg=pav_cfg,
+                    tests=self.last_tests,
+                    outfile=self.outfile
+                )
 
-        if report_status:
-            print_from_tests(
-                pav_cfg=pav_cfg,
-                tests=self.last_tests,
-                outfile=self.outfile
-            )
-
-        self._write_run_data(args.run_data, series_obj)
+            self._write_run_data(args.run_data, series_obj)
 
         return 0
 


### PR DESCRIPTION
This change fixes an error that causes a series' result logging to be skipped entirely if any test in that series fails.